### PR TITLE
Knock ragdolls away on player death

### DIFF
--- a/Assets/Editor/RagdollControllerEditor.cs
+++ b/Assets/Editor/RagdollControllerEditor.cs
@@ -13,7 +13,7 @@ public class RagdollControllerEditor : Editor
         {
             if (Application.isPlaying)
             {
-                ragdoll.EnableRagdoll();
+                ragdoll.EnableRagdoll(Vector3.zero);
             }
         }
     }

--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -184,6 +184,7 @@ MonoBehaviour:
   hudController: {fileID: 555885729091202788}
   meshBase: {fileID: 5330336945653279977}
   playerIK: {fileID: 142658303258642700}
+  deathKnockbackForceMultiplier: 10
   hitSounds: {fileID: 11400000, guid: 90b0dc5583765d64f81545c255b0fa3a, type: 2}
   extraHitSounds: {fileID: 11400000, guid: c5daa2802fa89a54986d53f2fc13cb8f, type: 2}
 --- !u!114 &6717855691676836013
@@ -241,6 +242,7 @@ MonoBehaviour:
   - {fileID: 3287810421338184656}
   - {fileID: 3287810421863630874}
   animatorToDisable: {fileID: 289053663840324231}
+  rigidbodyToPush: {fileID: 3287810421183947676}
 --- !u!82 &7607358150439154286
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Augment/AugmentImplementations/ContinuousDamage.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/ContinuousDamage.cs
@@ -15,7 +15,7 @@ public class ContinuousDamage : MonoBehaviour
 
     private HitboxController hitbox;
 
-    void Start()
+    private void Start()
     {
         hitbox = transform.parent.GetComponent<HitboxController>();
         if (hitbox && hitbox.health)
@@ -26,14 +26,14 @@ public class ContinuousDamage : MonoBehaviour
 
     private void OnDeath(HealthController healthController, float damage, DamageInfo info)
     {
-        this.enabled = false;
+        enabled = false;
     }
 
     private void Update()
     {
         if (hitbox && Time.time - lastDamageTime > 1 / damageRate)
         {
-            hitbox.DamageCollider(new DamageInfo(source, damage));
+            hitbox.DamageCollider(new DamageInfo(source, damage, transform.position, -hitbox.transform.forward));
             lastDamageTime = Time.time;
         }
     }

--- a/Assets/Scripts/Augment/ProjectileDamageController.cs
+++ b/Assets/Scripts/Augment/ProjectileDamageController.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
-// TODO use this
 public struct DamageInfo
 {
     public PlayerManager sourcePlayer;
@@ -13,25 +9,27 @@ public struct DamageInfo
     public Vector3 position;
 
     public Vector3 force;
-    public DamageInfo(PlayerManager source, float damage)
+    public DamageInfo(PlayerManager source, float damage, Vector3 position, Vector3 force)
     {
         this.sourcePlayer = source;
         this.damage = damage;
 
         // Todo, re-implement this with actual damage position and force
-        this.position = Vector3.zero;
-        this.force = Vector3.zero;
+        this.position = position;
+        this.force = force;
     }
 }
 
 public class ProjectileDamageController : MonoBehaviour, ProjectileModifier
 {
     public PlayerManager player;
+
     public void Attach(ProjectileController projectile)
     {
         player = projectile.player;
         projectile.OnHitboxCollision += DamageHitbox;
     }
+
     public void Detach(ProjectileController projectile)
     {
         projectile.OnHitboxCollision -= DamageHitbox;
@@ -39,7 +37,7 @@ public class ProjectileDamageController : MonoBehaviour, ProjectileModifier
 
     private void DamageHitbox(HitboxController controller, ref ProjectileState state)
     {
-        DamageInfo info = new DamageInfo(player, state.damage);
+        var info = new DamageInfo(player, state.damage, state.position, state.direction);
         if (controller.health && !state.hitHealthControllers.Contains(controller.health))
         {
             state.hitHealthControllers.Add(controller.health);

--- a/Assets/Scripts/ExplosionController.cs
+++ b/Assets/Scripts/ExplosionController.cs
@@ -44,26 +44,26 @@ public class ExplosionController : MonoBehaviour
     {
         visualEffect.enabled = true;
         visualEffect.SendEvent("OnPlay");
-        Collider[] colliderList = Physics.OverlapSphere(transform.position, radius, hitBoxLayers);
-        foreach (Collider collider in colliderList)
+        var targets = Physics.OverlapSphere(transform.position, radius, hitBoxLayers);
+        foreach (var target in targets)
         {
-            DealDamage(collider, sourcePlayer);
+            DealDamage(target, sourcePlayer);
         }
         Destroy(gameObject, 4);
     }
 
-    private void DealDamage(Collider collider, PlayerManager sourcePlayer)
+    private void DealDamage(Collider target, PlayerManager sourcePlayer)
     {
-        HitboxController controller = collider.GetComponent<HitboxController>();
-        bool hasHealth = controller.health;
-        if (hasHealth && !hitHealthControllers.Contains(controller.health))
+        var hitbox = target.GetComponent<HitboxController>();
+        bool hasHealth = hitbox.health;
+        if (hasHealth && !hitHealthControllers.Contains(hitbox.health))
         {
-            hitHealthControllers.Add(controller.health);
-            float scaledDamage = damage * damageCurve.Evaluate(Vector3.Distance(collider.transform.position, transform.position) / radius);
-            controller.DamageCollider(new DamageInfo(sourcePlayer, scaledDamage));
+            hitHealthControllers.Add(hitbox.health);
+            var scaledDamage = damage * damageCurve.Evaluate(Vector3.Distance(target.transform.position, transform.position) / radius);
+            hitbox.DamageCollider(new DamageInfo(sourcePlayer, scaledDamage, target.transform.position, (target.transform.position - transform.position).normalized));
         }
 
-        if (hasHealth && controller.health.TryGetComponent<Rigidbody>(out var rigidbody))
+        if (hasHealth && hitbox.health.TryGetComponent<Rigidbody>(out var rigidbody))
         {
             rigidbody.AddExplosionForce(knockbackForce, transform.position, radius * 1.2f, knockbackLiftFactor);
         }

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -51,6 +51,9 @@ public class PlayerManager : MonoBehaviour
     [SerializeField]
     private PlayerIK playerIK;
 
+    [SerializeField]
+    private float deathKnockbackForceMultiplier = 10;
+
 
     private BiddingPlatform selectedBiddingPlatform;
     public BiddingPlatform SelectedBiddingPlatform
@@ -104,12 +107,13 @@ public class PlayerManager : MonoBehaviour
             killer = lastPlayerThatHitMe;
         }
         onDeath?.Invoke(killer, this);
-        TurnIntoRagdoll();
+        TurnIntoRagdoll(info);
         hudController.DisplayDeathScreen(killer.identity);
     }
 
-    void TurnIntoRagdoll()
+    void TurnIntoRagdoll(DamageInfo info)
     {
+        GetComponent<Rigidbody>().GetAccumulatedForce();
         // Disable components
         GetComponent<PlayerMovement>().enabled = false;
         healthController.enabled = false;
@@ -121,7 +125,8 @@ public class PlayerManager : MonoBehaviour
 
         // TODO: Make accurate hitbox forces for the different limbs of the player
 
-        GetComponent<RagdollController>().EnableRagdoll();
+        var force = info.force.normalized * info.damage * deathKnockbackForceMultiplier;
+        GetComponent<RagdollController>().EnableRagdoll(force);
     }
 
     /// <summary>

--- a/Assets/Scripts/Interactables/DeathTriggerScript.cs
+++ b/Assets/Scripts/Interactables/DeathTriggerScript.cs
@@ -4,9 +4,9 @@ public class DeathTriggerScript : MonoBehaviour
 {
     private void OnTriggerEnter(Collider other)
     {
-        if (other.TryGetComponent<HitboxController>(out HitboxController hitbox)) 
+        if (other.TryGetComponent<HitboxController>(out var hitbox)) 
         {
-            hitbox.DamageCollider(new DamageInfo(hitbox.health.GetComponent<PlayerManager>(), 99999));
+            hitbox.DamageCollider(new DamageInfo(hitbox.health.GetComponent<PlayerManager>(), 1000, hitbox.transform.position, Vector3.zero));
         }
     }
 }

--- a/Assets/Scripts/RagdollController.cs
+++ b/Assets/Scripts/RagdollController.cs
@@ -19,7 +19,10 @@ public class RagdollController : MonoBehaviour
     [SerializeField]
     private Animator animatorToDisable;
 
-    public void EnableRagdoll()
+    [SerializeField]
+    private Rigidbody rigidbodyToPush;
+
+    public void EnableRagdoll(Vector3 knockbackForce)
     {
         animatorToDisable.enabled = false;
 
@@ -43,5 +46,7 @@ public class RagdollController : MonoBehaviour
             rigidbody.isKinematic = false;
             rigidbody.useGravity = true;
         }
+
+        rigidbodyToPush.AddForce(knockbackForce, ForceMode.Impulse);
     }
 }


### PR DESCRIPTION
- Provide direction of shot in damage info
- Use this to knock the players' torso back (more complex behaviour could be added later, but this works well enough)
- Determine knockback force based on damage (this works well for explosions too)

![ragdoll](https://github.com/hackerspace-ntnu/Prosjekt-Spill-H22/assets/44986729/64af65b8-d517-4f09-bbff-de52d87fa265)

![ragsplosion](https://github.com/hackerspace-ntnu/Prosjekt-Spill-H22/assets/44986729/ee797795-f8df-4f23-8eb5-8df87417fb20)

Closes #316 