### PR TITLE
Make displayed stats match actual stats and adjust ranges

### DIFF
--- a/Assets/Prefabs/GunParts/BulletBarrel.prefab
+++ b/Assets/Prefabs/GunParts/BulletBarrel.prefab
@@ -630,9 +630,8 @@ MonoBehaviour:
   projectileRotation: {x: 0, y: 0, z: 0, w: 1}
   stats: {fileID: 0}
   player: {fileID: 0}
-  maxDistance: 40
-  collisionSamples: 80
-  bulletsPerShot: 1
+  maxDistance: 100
+  collisionSamplesPerUnit: 2
   trail: {fileID: 1393106611541694855}
   flash: {fileID: 261841362781268065}
   animator: {fileID: 2824888147584701410}

--- a/Assets/Prefabs/GunParts/CannonBarrel.prefab
+++ b/Assets/Prefabs/GunParts/CannonBarrel.prefab
@@ -203,13 +203,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   statModifiers:
   - name: ProjectileDamage
-    addition: 30
+    addition: 40
     multiplier: 0
     exponential: 1
   - name: Firerate
     addition: 0
     multiplier: 0
     exponential: 0.3
+  - name: ProjectileSpeedFactor
+    addition: 0
+    multiplier: 0
+    exponential: 0.5
   outputs:
   - {fileID: 5765902433490691002}
   attachmentPoints:
@@ -233,7 +237,6 @@ MonoBehaviour:
   animator: {fileID: 6553004223414227404}
   maxProjectiles: 300
   maxDistance: 100
-  speed: 9
   size: 0.2
   vfx: {fileID: 562807672298037748}
   shouldRicochet: 0

--- a/Assets/Prefabs/GunParts/CoilBarrel.prefab
+++ b/Assets/Prefabs/GunParts/CoilBarrel.prefab
@@ -370,9 +370,8 @@ MonoBehaviour:
   projectileRotation: {x: 0, y: 0, z: 0, w: 1}
   stats: {fileID: 0}
   player: {fileID: 0}
-  maxDistance: 40
-  collisionSamples: 80
-  bulletsPerShot: 1
+  maxDistance: 100
+  collisionSamplesPerUnit: 2
   trail: {fileID: 6753720039035056053}
   flash: {fileID: 261841362781268065}
   animator: {fileID: 8505203738795632164}

--- a/Assets/Prefabs/GunParts/ShotgunBarrel.prefab
+++ b/Assets/Prefabs/GunParts/ShotgunBarrel.prefab
@@ -620,9 +620,8 @@ MonoBehaviour:
   projectileRotation: {x: 0, y: 0, z: 0, w: 1}
   stats: {fileID: 0}
   player: {fileID: 0}
-  maxDistance: 10
-  collisionSamples: 30
-  bulletsPerShot: 10
+  maxDistance: 15
+  collisionSamplesPerUnit: 3
   trail: {fileID: 1393106611541694855}
   flash: {fileID: 261841362781268065}
   animator: {fileID: 6403918129687704287}

--- a/Assets/Prefabs/GunParts/ShotgunBarrel.prefab
+++ b/Assets/Prefabs/GunParts/ShotgunBarrel.prefab
@@ -596,6 +596,10 @@ MonoBehaviour:
     addition: 10
     multiplier: 0
     exponential: 1
+  - name: ProjectilesPerShot
+    addition: 0
+    multiplier: 10
+    exponential: 1
   outputs:
   - {fileID: 5765902433490691002}
   attachmentPoints:

--- a/Assets/Prefabs/UI/PlayerStatUI.prefab
+++ b/Assets/Prefabs/UI/PlayerStatUI.prefab
@@ -56,9 +56,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   statContainer: {fileID: 3517448734813626926}
   playerNameText: {fileID: 5648608041759069520}
-  chipsText: {fileID: 0}
   gunPreviewPanel: {fileID: 6908086682209798948}
-  chip: {fileID: 0}
   damageBar: {fileID: 809994374641583378}
   fireRateBar: {fileID: 3314896837149191081}
   projectilesPerShotBar: {fileID: 6994510046160422822}
@@ -828,7 +826,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8714461546252577768, guid: 17df745e02bd45b0c9436e1b60f6ffa4, type: 3}
       propertyPath: defaultMaxValue
-      value: 16
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1045,7 +1043,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8714461546252577768, guid: 17df745e02bd45b0c9436e1b60f6ffa4, type: 3}
       propertyPath: defaultMaxValue
-      value: 20
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Augment/AugmentImplementations/Hat/MeshProjectileController.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Hat/MeshProjectileController.cs
@@ -17,10 +17,9 @@ public class MeshProjectileController : ProjectileController
     private int maxProjectiles = 300;
 
     [FormerlySerializedAs("hatMaxDistance")] [SerializeField]
-    private float maxDistance = 20f;
+    private float maxDistance = 20;
 
-    [FormerlySerializedAs("hatSpeed")] [SerializeField]
-    private float speed = 10f;
+    private const float baseSpeed = 20;
 
     [FormerlySerializedAs("hatSize")] [SerializeField]
     private float size = .2f;
@@ -77,7 +76,7 @@ public class MeshProjectileController : ProjectileController
     public override void InitializeProjectile(GunStats stats)
     {
         loadedProjectile = new ProjectileState(stats, projectileOutput);
-        loadedProjectile.maxDistance = this.maxDistance;
+        loadedProjectile.maxDistance = maxDistance;
 
         animator.OnFire(stats.Ammo);
     }
@@ -87,7 +86,7 @@ public class MeshProjectileController : ProjectileController
         if (loadedProjectile == null) return;
 
         loadedProjectile.active = true;
-        loadedProjectile.speed = speed;
+        loadedProjectile.speed = baseSpeed;
         OnProjectileInit?.Invoke(ref loadedProjectile, stats);
         for (int i = 0; i < maxProjectiles; i++)
         {

--- a/Assets/Scripts/Augment/BulletController.cs
+++ b/Assets/Scripts/Augment/BulletController.cs
@@ -11,11 +11,7 @@ public class BulletController : ProjectileController
 
     private int vfxPositionsPerSample = 3;
 
-    private float bulletSpeed = 50f;
-
-    [SerializeField]
-    private int bulletsPerShot = 1;
-    public int BulletsPerShot => bulletsPerShot;
+    private const float baseSpeed = 50f;
 
     private VFXTextureFormatter trailPosTexture;
 
@@ -39,6 +35,7 @@ public class BulletController : ProjectileController
 
     private void Start()
     {
+        var bulletsPerShot = Mathf.FloorToInt(stats.ProjectilesPerShot);
         flash.transform.position = projectileOutput.position;
         trailPosTexture = new VFXTextureFormatter(vfxPositionsPerSample * collisionSamples * bulletsPerShot);
         trail.SetTexture("Position", this.trailPosTexture.Texture);
@@ -62,9 +59,8 @@ public class BulletController : ProjectileController
         animator.OnFire(stats.Ammo);
 
         // TODO: Possibly standardize this better
-        for (int k = 0; k < bulletsPerShot; k++)
+        for (int k = 0; k < stats.ProjectilesPerShot; k++)
         {
-
             Quaternion randomSpread = Quaternion.Lerp(Quaternion.identity, Random.rotation, stats.ProjectileSpread);
 
             projectile.active = true;
@@ -83,7 +79,7 @@ public class BulletController : ProjectileController
 
             OnProjectileInit?.Invoke(ref projectile, stats);
 
-            projectile.speed = bulletSpeed * stats.ProjectileSpeedFactor;
+            projectile.speed = baseSpeed * stats.ProjectileSpeedFactor;
 
             int sampleNum = 0;
 
@@ -129,8 +125,8 @@ public class BulletController : ProjectileController
             }
 
             trailPosTexture.ApplyChanges();
-            // Play the flash and trail
         }
+        // Play the flash and trail
         trail.SendEvent("OnPlay");
         flash.SendEvent("OnPlay");
     }

--- a/Assets/Scripts/Augment/BulletController.cs
+++ b/Assets/Scripts/Augment/BulletController.cs
@@ -7,9 +7,11 @@ public class BulletController : ProjectileController
     private float maxDistance = 20;
 
     [SerializeField]
-    private int collisionSamples = 30;
+    private int collisionSamplesPerUnit = 3;
 
-    private int vfxPositionsPerSample = 3;
+    private int collisionSamples;
+
+    private const int vfxPositionsPerSample = 3;
 
     private const float baseSpeed = 50f;
 
@@ -35,7 +37,8 @@ public class BulletController : ProjectileController
 
     private void Start()
     {
-        var bulletsPerShot = Mathf.FloorToInt(stats.ProjectilesPerShot);
+        collisionSamples = Mathf.CeilToInt(collisionSamplesPerUnit * maxDistance);
+        var bulletsPerShot = Mathf.CeilToInt(stats.ProjectilesPerShot);
         flash.transform.position = projectileOutput.position;
         trailPosTexture = new VFXTextureFormatter(vfxPositionsPerSample * collisionSamples * bulletsPerShot);
         trail.SetTexture("Position", this.trailPosTexture.Texture);
@@ -58,11 +61,11 @@ public class BulletController : ProjectileController
     {
         animator.OnFire(stats.Ammo);
 
-        // TODO: Possibly standardize this better
         for (int k = 0; k < stats.ProjectilesPerShot; k++)
         {
             Quaternion randomSpread = Quaternion.Lerp(Quaternion.identity, Random.rotation, stats.ProjectileSpread);
 
+            // TODO: Possibly standardize this better
             projectile.active = true;
             projectile.distanceTraveled = 0f;
             projectile.damage = stats.ProjectileDamage;

--- a/Assets/Scripts/Augment/BulletModifiers/KnockbackOnShotModifier.cs
+++ b/Assets/Scripts/Augment/BulletModifiers/KnockbackOnShotModifier.cs
@@ -24,8 +24,7 @@ public class KnockbackOnShotModifier: MonoBehaviour, ProjectileModifier
     public void Attach(ProjectileController projectile)
     {
         projectile.OnHitboxCollision += KnockAwayTargets;
-        var bulletController = projectile.gameObject.GetComponent<BulletController>();
-        bulletAmount = bulletController == null || bulletController.BulletsPerShot == 0 ? 1f : bulletController.BulletsPerShot;
+        bulletAmount = projectile.stats.ProjectilesPerShot;
         calculatedPushPower = (pushPower / bulletAmount) * (1f + (float)Math.Log10(bulletAmount));
     }
 

--- a/Assets/Scripts/Augment/BulletModifiers/RecoilModifier.cs
+++ b/Assets/Scripts/Augment/BulletModifiers/RecoilModifier.cs
@@ -38,11 +38,13 @@ public class RecoilModifier : MonoBehaviour, ProjectileModifier
 
     private void KnockAwayOnShot(ref ProjectileState state, GunStats stats)
     {
+        if (!gunController.player)
+            return;
+
         Vector3 normal = -gunController.transform.forward;
 
         float calculatedPushPowerForPlayer = (calculatedPushPower / stats.Firerate) * (baseFireRateAdder + (float)Math.Log(stats.Firerate));
 
         gunController.player.GetComponent<Rigidbody>().AddForce(normal * calculatedPushPowerForPlayer, ForceMode.Impulse);
-
     }
 }

--- a/Assets/Scripts/Augment/BulletModifiers/RecoilModifier.cs
+++ b/Assets/Scripts/Augment/BulletModifiers/RecoilModifier.cs
@@ -27,8 +27,7 @@ public class RecoilModifier : MonoBehaviour, ProjectileModifier
     public void Attach(ProjectileController projectile)
     {
         projectile.OnProjectileInit += KnockAwayOnShot;
-        var bulletController = projectile.gameObject.GetComponent<BulletController>();
-        bulletAmount = bulletController == null || bulletController.BulletsPerShot == 0 ? 1f : bulletController.BulletsPerShot;
+        bulletAmount = projectile.stats.ProjectilesPerShot;
         calculatedPushPower = (pushPower / bulletAmount) * (1f + (float)Math.Log10(bulletAmount));
     }
 

--- a/Assets/VFX/SmokeTrail_Instant.vfx
+++ b/Assets/VFX/SmokeTrail_Instant.vfx
@@ -388,9 +388,9 @@ MonoBehaviour:
   - {fileID: 8926484042661614656}
   - {fileID: 8926484042661614805}
   dataType: 1
-  capacity: 15000
+  capacity: 75000
   stripCapacity: 75
-  particlePerStripCount: 200
+  particlePerStripCount: 1000
   needsComputeBounds: 1
   boundsMode: 2
   m_Space: 1


### PR DESCRIPTION
- Fix displayed shotgun projectile count
- Projectile speed for all barrels, particularily the cannon which has reduced speed (dunno what to do with the hitscan barrels here)
- Refactored collision sample calculation to let us specify samples per unit distance instead of total sample amount, so that one only needs to increase the max distance in order to actually increase the range.
- Increased the ranges of all hitscan weapons, including the shotgun.
  - 100 units is just enough to hit things on the other side of both maps, as long as they aren't mere dots in the distance. Should be sufficient.

May actually resolve #183 but I'm not entirely sure