### PR TITLE
Improve player movement

### DIFF
--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -63,14 +63,15 @@ MonoBehaviour:
   airDrag: 1
   maxVelocityBeforeExtraDamping: 10
   extraDamping: 25
+  dashDamping: 4
   strafeForceGrounded: 60
   strafeForceCrouched: 30
   strafeForceInAir: 30
   jumpForce: 10
   leapForce: 12.5
   leapTimeout: 0.25
-  consecutiveLeapHeightMultiplier: 0.5
-  consecutiveLeapForwardMultiplier: 1.5
+  dashHeightMultiplier: 0.5
+  dashForwardMultiplier: 1
   crouchedHeightOffset: 0.8
   airThreshold: 0.4
   slopeAngleThreshold: 50

--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -59,16 +59,16 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 65335
   lookSpeed: 3
-  maxVelocity: 10
+  maxVelocity: 20
   strafeForceGrounded: 60
   strafeForceCrouched: 30
-  strafeForceInAir: 16
+  strafeForceInAir: 10
   drag: 6
-  airDrag: 2
+  airDrag: 1
   jumpForce: 10
   leapForce: 12.5
-  jumpTimeout: 0.5
-  leapTimeout: 0.875
+  jumpTimeout: 0
+  leapTimeout: 0
   crouchedHeightOffset: 0.8
   airThreshold: 0.4
   slopeAngleThreshold: 50
@@ -145,8 +145,8 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 71015680234268067}
   serializedVersion: 4
-  m_Mass: 10
-  m_Drag: 4
+  m_Mass: 5
+  m_Drag: 0
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}

--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -63,7 +63,6 @@ MonoBehaviour:
   airDrag: 1
   maxVelocityBeforeExtraDamping: 10
   extraDamping: 25
-  dashDamping: 4
   strafeForceGrounded: 60
   strafeForceCrouched: 30
   strafeForceInAir: 30
@@ -72,6 +71,7 @@ MonoBehaviour:
   leapTimeout: 0.25
   dashHeightMultiplier: 0.5
   dashForwardMultiplier: 1
+  dashDamping: 0.5
   crouchedHeightOffset: 0.8
   airThreshold: 0.4
   slopeAngleThreshold: 50

--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -59,16 +59,18 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 65335
   lookSpeed: 3
-  maxVelocity: 20
+  groundDrag: 6
+  airDrag: 1
+  maxVelocityBeforeExtraDamping: 10
+  extraDamping: 25
   strafeForceGrounded: 60
   strafeForceCrouched: 30
-  strafeForceInAir: 10
-  drag: 6
-  airDrag: 1
+  strafeForceInAir: 30
   jumpForce: 10
   leapForce: 12.5
-  jumpTimeout: 0
-  leapTimeout: 0
+  leapTimeout: 0.25
+  consecutiveLeapHeightMultiplier: 0.5
+  consecutiveLeapForwardMultiplier: 1.5
   crouchedHeightOffset: 0.8
   airThreshold: 0.4
   slopeAngleThreshold: 50

--- a/Assets/Scripts/Control&Input/PlayerMovement.cs
+++ b/Assets/Scripts/Control&Input/PlayerMovement.cs
@@ -69,6 +69,9 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField]
     private float dashDamping = 4f;
 
+    [SerializeField]
+    private float minDashVelocity = 8f;
+
     private bool isDashing = false;
 
     [Header("State")]
@@ -275,6 +278,13 @@ public class PlayerMovement : MonoBehaviour
         // Limit velocity when not grounded
         if (state == PlayerState.GROUNDED)
             return;
+
+        if (isDashing)
+        {
+            var directionalForces = new Vector3(body.velocity.x, 0, body.velocity.z);
+            if (directionalForces.magnitude < minDashVelocity)
+                isDashing = false;
+        }
         // Add extra drag when player velocity is too high
         var maxVelocityReached = Mathf.Abs(body.velocity.x) > maxVelocityBeforeExtraDamping || Mathf.Abs(body.velocity.z) > maxVelocityBeforeExtraDamping;
         if (maxVelocityReached)

--- a/Assets/Scripts/Control&Input/PlayerMovement.cs
+++ b/Assets/Scripts/Control&Input/PlayerMovement.cs
@@ -114,8 +114,8 @@ public class PlayerMovement : MonoBehaviour
     {
         inputManager = player;
         inputManager.onSelect += OnJump;
-        inputManager.onCrouchPerformed += SetCrouch;
-        inputManager.onCrouchCanceled += SetCrouch;
+        inputManager.onCrouchPerformed += OnCrouch;
+        inputManager.onCrouchCanceled += OnCrouch;
         localCameraHeight = inputManager.transform.localPosition.y;
     }
 
@@ -138,7 +138,7 @@ public class PlayerMovement : MonoBehaviour
         body.AddForce(Vector3.up * jumpForce, ForceMode.VelocityChange);
     }
 
-    private void SetCrouch(InputAction.CallbackContext ctx)
+    private void OnCrouch(InputAction.CallbackContext ctx)
     {
         if (LeanTween.isTweening(inputManager.gameObject))
         {
@@ -150,10 +150,10 @@ public class PlayerMovement : MonoBehaviour
         {
             if (IsInAir())
             {
-                onLanding += SetCrouchTrue;
+                onLanding += StartCrouch;
                 return;
             }
-            SetCrouchTrue();
+            StartCrouch();
         }
             
         if (ctx.canceled)
@@ -162,12 +162,12 @@ public class PlayerMovement : MonoBehaviour
             strafeForce = strafeForceGrounded;
             inputManager.gameObject.LeanMoveLocalY(localCameraHeight, 0.2f);
             isDashing = false;
-            onLanding -= SetCrouchTrue;
+            onLanding -= StartCrouch;
         }
             
     }
 
-    private void SetCrouchTrue()
+    private void StartCrouch()
     {
         animator.SetBool("Crouching", true);
         strafeForce = strafeForceCrouched;


### PR DESCRIPTION
- There is now 0 drag on Y for players falling, giving no terminal velocity
- Remove quirk with floating point rounding by applying fixedUpdate too early
- Gave players more control when in air after jumping normally/falling
- Starting to hold crouch when you are in air until you land will now get players to crouch once they land
- Added dashing with much less air drag if you time leaps consecutively, see gif below
   - Dashes can be cancelled into a leap by letting go of crouch and holding crouch again while still in air
![dashing_optimized_github](https://github.com/hackerspace-ntnu/Red-Planet-Rampage/assets/54811121/3f20764e-3e70-4676-96fc-82d16e67610c)

Future todo for other PRs:
- Dashing lines effect around screen of dashing player
- Dash jumping noice that goes up a pitch for each consecutive dash jump
- Leap noice
- Restructure some levels to accomodate for leap height (creating shortcuts to places of height and parkour opportunities)

