### PR TITLE
Decouple first person and third person gun

### DIFF
--- a/Assets/Animation/Augments/revolverReload.anim
+++ b/Assets/Animation/Augments/revolverReload.anim
@@ -1586,46 +1586,7 @@ AnimationClip:
         inWeight: 0
         outWeight: 0
       - serializedVersion: 3
-        time: 0.016666668
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 2.9166667
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_IsActive
-    path: YiiHawArm
-    classID: 1
-    script: {fileID: 0}
-    flags: 0
-  - serializedVersion: 2
-    curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 0.016666668
+        time: 0.033333335
         value: 1
         inSlope: Infinity
         outSlope: Infinity
@@ -1958,15 +1919,6 @@ AnimationClip:
       script: {fileID: 0}
       typeID: 4
       customType: 4
-      isPPtrCurve: 0
-      isIntCurve: 0
-      isSerializeReferenceCurve: 0
-    - serializedVersion: 2
-      path: 127008410
-      attribute: 2086281974
-      script: {fileID: 0}
-      typeID: 1
-      customType: 0
       isPPtrCurve: 0
       isIntCurve: 0
       isSerializeReferenceCurve: 0
@@ -2539,45 +2491,6 @@ AnimationClip:
     attribute: localEulerAnglesRaw.z
     path: 
     classID: 4
-    script: {fileID: 0}
-    flags: 0
-  - serializedVersion: 2
-    curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 0.016666668
-        value: 1
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 2.9166667
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_IsActive
-    path: YiiHawArm
-    classID: 1
     script: {fileID: 0}
     flags: 0
   - serializedVersion: 2
@@ -7004,7 +6917,7 @@ AnimationClip:
         inWeight: 0
         outWeight: 0
       - serializedVersion: 3
-        time: 0.016666668
+        time: 0.033333335
         value: 1
         inSlope: Infinity
         outSlope: Infinity
@@ -7885,8 +7798,22 @@ AnimationClip:
   m_HasGenericRootTransform: 1
   m_HasMotionFloatCurves: 0
   m_Events:
+  - time: 0.016666668
+    functionName: ToggleArm
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
   - time: 0.23333333
     functionName: TriggerSteam
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 2.9333334
+    functionName: ToggleArm
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/PinAnimator.cs
+++ b/Assets/PinAnimator.cs
@@ -18,9 +18,9 @@ public class PinAnimator : AugmentAnimator
         time = 1 / stats.Firerate.Value();
     }
 
-    public override void OnReload(int ammo) { }
+    public override void OnReload(GunStats stats) { }
 
-    public override void OnFire(int remainingAmmo)
+    public override void OnFire(GunStats stats)
     {
         transform.localPosition = Vector3.zero;
         LeanTween.moveLocalZ(gameObject, maxDist, time * (1 - delay))

--- a/Assets/Prefabs/ArenaCamera.prefab
+++ b/Assets/Prefabs/ArenaCamera.prefab
@@ -48,9 +48,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -65,7 +73,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 3967
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -115,6 +123,16 @@ MonoBehaviour:
   m_Dithering: 0
   m_ClearDepth: 1
   m_AllowXRRendering: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
   m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0

--- a/Assets/Prefabs/GunParts/HatBarrel.prefab
+++ b/Assets/Prefabs/GunParts/HatBarrel.prefab
@@ -456,7 +456,7 @@ MonoBehaviour:
   animator: {fileID: 5376405389655812532}
   maxProjectiles: 300
   maxDistance: 250
-  size: 0.6
+  size: 0.35
   visualSize: 120
   vfx: {fileID: 1746704752495276340}
   shouldRicochet: 1

--- a/Assets/Prefabs/GunParts/RevolverBody.prefab
+++ b/Assets/Prefabs/GunParts/RevolverBody.prefab
@@ -5296,6 +5296,7 @@ GameObject:
   - component: {fileID: 6604547189345139608}
   - component: {fileID: 1952356920142457975}
   - component: {fileID: 5886082362856684746}
+  - component: {fileID: 3857694734235012439}
   m_Layer: 0
   m_Name: RevolverBody
   m_TagString: Untagged
@@ -5363,6 +5364,19 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &3857694734235012439
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6604547189345139607}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3aa4de144f24b42468ea229da449236f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  attachmentSite: {fileID: 1985392096533510068}
 --- !u!1 &6830956434835172052
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/GunParts/lawnMower.prefab
+++ b/Assets/Prefabs/GunParts/lawnMower.prefab
@@ -169,6 +169,7 @@ GameObject:
   - component: {fileID: 6114546431771368496}
   - component: {fileID: 8412244710553485749}
   - component: {fileID: 2789145164633129729}
+  - component: {fileID: 1204770057262295902}
   m_Layer: 0
   m_Name: lawnMower
   m_TagString: Untagged
@@ -272,6 +273,22 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &1204770057262295902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1809122596642359082}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 77092469685134548aad694f939fb68c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  handString: {fileID: 5418090658039998355}
+  animator: {fileID: 7075965889028507396}
+  handAnimator: {fileID: 2789145164633129729}
+  exhaustParticles: {fileID: 571917691106623531}
 --- !u!1 &2480505416070711020
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -2024,6 +2024,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: YiiHaw
       objectReference: {fileID: 0}
+    - target: {fileID: 3195995323192703229, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
+      propertyPath: leftHandIKTransform
+      value: 
+      objectReference: {fileID: 3680236445534610840}
+    - target: {fileID: 3195995323192703229, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
+      propertyPath: rightHandIKTranform
+      value: 
+      objectReference: {fileID: 4604144610022740314}
     - target: {fileID: 3326176138852896576, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
       propertyPath: m_RootOrder
       value: 1
@@ -2223,6 +2231,16 @@ Rigidbody:
 --- !u!136 &3287810422978762219 stripped
 CapsuleCollider:
   m_CorrespondingSourceObject: {fileID: 1496441882, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
+  m_PrefabInstance: {fileID: 3287810421515891185}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &3680236445534610840 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2211959717696197737, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
+  m_PrefabInstance: {fileID: 3287810421515891185}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &4604144610022740314 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1316620135651827883, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
   m_PrefabInstance: {fileID: 3287810421515891185}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &5330336945653279977 stripped

--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -1416,8 +1416,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2192650951514295549}
-  - component: {fileID: 6995614115377055334}
-  - component: {fileID: 5493321919775659824}
+  - component: {fileID: 4170563085359155052}
+  - component: {fileID: 7354243706276186767}
   m_Layer: 3
   m_Name: GunHolder
   m_TagString: Untagged
@@ -1432,15 +1432,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6965675563780692420}
-  m_LocalRotation: {x: 0, y: 0.7071068, z: 0.7071068, w: 0}
-  m_LocalPosition: {x: 0.00011059483, y: 0.00051207544, z: -0.0003212733}
-  m_LocalScale: {x: 0.05, y: 0.05, z: 0.05}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.39, y: -0.34, z: 0.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
-  m_Father: {fileID: 4604144610022740314}
+  m_Father: {fileID: 6507685450046118291}
   m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
---- !u!114 &6995614115377055334
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4170563085359155052
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1457,11 +1457,11 @@ MonoBehaviour:
   RightHandTarget: {fileID: 0}
   LeftHandTarget: {fileID: 0}
   player: {fileID: 0}
-  HasRecoil: 0
+  HasRecoil: 1
   triggerHeld: 0
   triggerPressed: 0
   target: {x: 0, y: 0, z: 0}
---- !u!114 &5493321919775659824
+--- !u!114 &7354243706276186767
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1619,7 +1619,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 1.837, z: -0.265}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 2192650951514295549}
   m_Father: {fileID: 71015680234268071}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2051,10 +2052,7 @@ PrefabInstance:
       objectReference: {fileID: 6717855691676836013}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1316620135651827883, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2192650951514295549}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
 --- !u!114 &142658303258642700 stripped
@@ -2191,11 +2189,6 @@ Rigidbody:
 --- !u!136 &3287810422978762219 stripped
 CapsuleCollider:
   m_CorrespondingSourceObject: {fileID: 1496441882, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
-  m_PrefabInstance: {fileID: 3287810421515891185}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &4604144610022740314 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1316620135651827883, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
   m_PrefabInstance: {fileID: 3287810421515891185}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &5330336945653279977 stripped

--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -74,6 +74,7 @@ MonoBehaviour:
   dashDamping: 0.5
   minDashVelocity: 8
   crouchedHeightOffset: 0.8
+  crouchedHeightGunOffset: 0.5
   airThreshold: 0.4
   slopeAngleThreshold: 50
   state: 1
@@ -184,7 +185,8 @@ MonoBehaviour:
   targetStartOffset: 0.9
   overrideAimTarget: 0
   ammoMaskItem: {fileID: 11400000, guid: a99e4b806f963ac45a0635c34182107a, type: 2}
-  gunHolder: {fileID: 2192650951514295549}
+  GunHolder: {fileID: 2192650951514295549}
+  GunOrigin: {fileID: 5285924196574601758}
   inputManager: {fileID: 0}
   identity: {fileID: 0}
   hudController: {fileID: 555885729091202788}
@@ -1157,6 +1159,75 @@ MonoBehaviour:
     y: 0
     width: 1
     height: 1
+--- !u!1 &3433598770842043782
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5285924196574601758}
+  - component: {fileID: 180929155250404221}
+  - component: {fileID: 2798034521173301447}
+  m_Layer: 3
+  m_Name: GunHoldPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5285924196574601758
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3433598770842043782}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.35}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2192650951514295549}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &180929155250404221
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3433598770842043782}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ff631b6f3d59cd4c8d253e00109042b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  projectile: {fileID: 0}
+  outputs: []
+  RightHandTarget: {fileID: 0}
+  LeftHandTarget: {fileID: 0}
+  player: {fileID: 0}
+  HasRecoil: 1
+  triggerHeld: 0
+  triggerPressed: 0
+  target: {x: 0, y: 0, z: 0}
+--- !u!114 &2798034521173301447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3433598770842043782}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a5d153951108c144a246beccd96ee7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Body: {fileID: 0}
+  Barrel: {fileID: 0}
+  Extension: {fileID: 0}
 --- !u!1 &4536483048541249167
 GameObject:
   m_ObjectHideFlags: 0
@@ -1416,8 +1487,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2192650951514295549}
-  - component: {fileID: 4170563085359155052}
-  - component: {fileID: 7354243706276186767}
   m_Layer: 3
   m_Name: GunHolder
   m_TagString: Untagged
@@ -1433,49 +1502,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6965675563780692420}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.39, y: -0.34, z: 0.5}
+  m_LocalPosition: {x: 0.307, y: -0.404, z: 0.268}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
-  m_Children: []
+  m_Children:
+  - {fileID: 5285924196574601758}
   m_Father: {fileID: 6507685450046118291}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4170563085359155052
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6965675563780692420}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2ff631b6f3d59cd4c8d253e00109042b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  projectile: {fileID: 0}
-  outputs: []
-  RightHandTarget: {fileID: 0}
-  LeftHandTarget: {fileID: 0}
-  player: {fileID: 0}
-  HasRecoil: 1
-  triggerHeld: 0
-  triggerPressed: 0
-  target: {x: 0, y: 0, z: 0}
---- !u!114 &7354243706276186767
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6965675563780692420}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1a5d153951108c144a246beccd96ee7a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Body: {fileID: 0}
-  Barrel: {fileID: 0}
-  Extension: {fileID: 0}
 --- !u!1 &7177846384712759188
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -184,6 +184,7 @@ MonoBehaviour:
   targetStartOffset: 0.9
   overrideAimTarget: 0
   ammoMaskItem: {fileID: 11400000, guid: a99e4b806f963ac45a0635c34182107a, type: 2}
+  gunHolder: {fileID: 2192650951514295549}
   inputManager: {fileID: 0}
   identity: {fileID: 0}
   hudController: {fileID: 555885729091202788}
@@ -1406,6 +1407,75 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 1
   m_SpriteSortPoint: 0
+--- !u!1 &6965675563780692420
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2192650951514295549}
+  - component: {fileID: 6995614115377055334}
+  - component: {fileID: 5493321919775659824}
+  m_Layer: 3
+  m_Name: GunHolder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2192650951514295549
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6965675563780692420}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0.7071068, w: 0}
+  m_LocalPosition: {x: 0.00011059483, y: 0.00051207544, z: -0.0003212733}
+  m_LocalScale: {x: 0.05, y: 0.05, z: 0.05}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 4604144610022740314}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
+--- !u!114 &6995614115377055334
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6965675563780692420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ff631b6f3d59cd4c8d253e00109042b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  projectile: {fileID: 0}
+  outputs: []
+  RightHandTarget: {fileID: 0}
+  LeftHandTarget: {fileID: 0}
+  player: {fileID: 0}
+  HasRecoil: 0
+  triggerHeld: 0
+  triggerPressed: 0
+  target: {x: 0, y: 0, z: 0}
+--- !u!114 &5493321919775659824
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6965675563780692420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a5d153951108c144a246beccd96ee7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Body: {fileID: 0}
+  Barrel: {fileID: 0}
+  Extension: {fileID: 0}
 --- !u!1 &7177846384712759188
 GameObject:
   m_ObjectHideFlags: 0
@@ -1981,7 +2051,10 @@ PrefabInstance:
       objectReference: {fileID: 6717855691676836013}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 1316620135651827883, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2192650951514295549}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
 --- !u!114 &142658303258642700 stripped
@@ -2118,6 +2191,11 @@ Rigidbody:
 --- !u!136 &3287810422978762219 stripped
 CapsuleCollider:
   m_CorrespondingSourceObject: {fileID: 1496441882, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
+  m_PrefabInstance: {fileID: 3287810421515891185}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &4604144610022740314 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1316620135651827883, guid: 27ac4408b426ae745a1792dde18c79ba, type: 3}
   m_PrefabInstance: {fileID: 3287810421515891185}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &5330336945653279977 stripped

--- a/Assets/Prefabs/Input/PlayerBidding.prefab
+++ b/Assets/Prefabs/Input/PlayerBidding.prefab
@@ -73,6 +73,7 @@ MonoBehaviour:
   dashDamping: 4
   minDashVelocity: 8
   crouchedHeightOffset: 0.3
+  crouchedHeightGunOffset: 0.28
   airThreshold: 0.4
   slopeAngleThreshold: 50
   state: 1
@@ -183,6 +184,8 @@ MonoBehaviour:
   targetStartOffset: 0.28
   overrideAimTarget: 0
   ammoMaskItem: {fileID: 0}
+  GunHolder: {fileID: 6507685450046118291}
+  GunOrigin: {fileID: 6507685450046118291}
   inputManager: {fileID: 0}
   identity: {fileID: 0}
   hudController: {fileID: 555885729091202788}

--- a/Assets/Scenes/GrandCanyon.unity
+++ b/Assets/Scenes/GrandCanyon.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 1421388808}
-  m_IndirectSpecularColor: {r: 0.22070792, g: 0.06260562, b: 0.039305113, a: 1}
+  m_IndirectSpecularColor: {r: 0.22070818, g: 0.06260574, b: 0.0393052, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2710,164 +2710,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6763320930858482407, guid: 986aa6e08182d0a44ba89f5b73e2ac08, type: 3}
   m_PrefabInstance: {fileID: 980136063}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &984240219
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 984240222}
-  - component: {fileID: 984240221}
-  - component: {fileID: 984240220}
-  - component: {fileID: 984240223}
-  - component: {fileID: 984240224}
-  m_Layer: 0
-  m_Name: Main Camera
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!81 &984240220
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 984240219}
-  m_Enabled: 1
---- !u!20 &984240221
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 984240219}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_Iso: 200
-  m_ShutterSpeed: 0.005
-  m_Aperture: 16
-  m_FocusDistance: 10
-  m_FocalLength: 50
-  m_BladeCount: 5
-  m_Curvature: {x: 2, y: 11}
-  m_BarrelClipping: 0.25
-  m_Anamorphism: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 0
-  orthographic size: 5
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &984240222
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 984240219}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &984240223
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 984240219}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RenderShadows: 1
-  m_RequiresDepthTextureOption: 2
-  m_RequiresOpaqueTextureOption: 2
-  m_CameraType: 0
-  m_Cameras: []
-  m_RendererIndex: -1
-  m_VolumeLayerMask:
-    serializedVersion: 2
-    m_Bits: 1
-  m_VolumeTrigger: {fileID: 0}
-  m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
-  m_Antialiasing: 0
-  m_AntialiasingQuality: 2
-  m_StopNaN: 0
-  m_Dithering: 0
-  m_ClearDepth: 1
-  m_AllowXRRendering: 1
-  m_UseScreenCoordOverride: 0
-  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
-  m_RequiresDepthTexture: 0
-  m_RequiresColorTexture: 0
-  m_Version: 2
-  m_TaaSettings:
-    quality: 3
-    frameInfluence: 0.1
-    jitterScale: 1
-    mipBias: 0
-    varianceClampScale: 0.9
-    contrastAdaptiveSharpening: 0
---- !u!95 &984240224
-Animator:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 984240219}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 2b7caaa6ee4d1444ca740f3fa66c0344, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
 --- !u!1001 &1009435146
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5545,6 +5387,96 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6763320930858482407, guid: 986aa6e08182d0a44ba89f5b73e2ac08, type: 3}
   m_PrefabInstance: {fileID: 1743415659}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1817786832
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4560627545820911483, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560627545820911483, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560627545820911483, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 97
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560627545820911483, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -30
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560627545820911483, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.93587524
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560627545820911483, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.35233167
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560627545820911483, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560627545820911483, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560627545820911483, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 41.26
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560627545820911483, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560627545820911483, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560627545820911484, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      propertyPath: m_Name
+      value: ArenaCamera
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4560627545820911484, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1817786834}
+  m_SourcePrefab: {fileID: 100100000, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+--- !u!1 &1817786833 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4560627545820911484, guid: 660b1be87bd994ad3b4af96229be6598, type: 3}
+  m_PrefabInstance: {fileID: 1817786832}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &1817786834
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1817786833}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 2b7caaa6ee4d1444ca740f3fa66c0344, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &1872823693
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Augment/AugmentImplementations/AugmentAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/AugmentAnimator.cs
@@ -10,6 +10,6 @@ public abstract class AugmentAnimator : MonoBehaviour
     public AnimationEvent OnFireAnimationEnd;
 
     public abstract void OnInitialize(GunStats stats);
-    public abstract void OnReload(int ammo);
-    public abstract void OnFire(int remainingAmmo);
+    public abstract void OnReload(GunStats stats);
+    public abstract void OnFire(GunStats stats);
 }

--- a/Assets/Scripts/Augment/AugmentImplementations/BarrelFiringAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/BarrelFiringAnimator.cs
@@ -13,11 +13,11 @@ public class BarrelFiringAnimator : AugmentAnimator
         animator.speed = Mathf.Max(stats.Firerate, 1f);
     }
 
-    public override void OnReload(int ammo)
+    public override void OnReload(GunStats stats)
     {
     }
 
-    public override void OnFire(int remainingAmmo)
+    public override void OnFire(GunStats stats)
     {
         animator.SetTrigger("Fire");
         // TODO wait for firing animation to end

--- a/Assets/Scripts/Augment/AugmentImplementations/DDRBody.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/DDRBody.cs
@@ -82,7 +82,7 @@ public class DDRBody : GunBody
                 .setDelay(MusicTrackManager.Singleton.TrackOffset)
                 .setLoopPingPong()
                 .setOnComplete(
-                () => animator.OnFire(0));
+                () => animator.OnFire(gunController.stats));
 
             animator.OnInitialize(gunController.stats);
 
@@ -117,12 +117,12 @@ public class DDRBody : GunBody
         LeanTween.value(gameObject, SetFlashFactor, 0, 20f, 0.5f).setEasePunch();
 
         gunController.Reload(reloadEfficiencyPercentage * precision.Value.awardFactor);
-        animator.OnReload(1);
+        animator.OnReload(gunController.stats);
     }
 
     private void Fire(InputAction.CallbackContext ctx)
     {
-        animator.OnFire(gunController.stats.Ammo);
+        animator.OnFire(gunController.stats);
     }
 
     private void ArrowSelect(InputAction.CallbackContext ctx)

--- a/Assets/Scripts/Augment/AugmentImplementations/DDRBody.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/DDRBody.cs
@@ -114,7 +114,7 @@ public class DDRBody : GunBody
             .setOnComplete(
             () => precisionText.enabled = false);
 
-        LeanTween.value(gameObject, SetFlashFactor, 0, 20f, 0.5f).setEasePunch();
+        LeanTween.value(gameObject, SetFlashFactor, 0, 50f, 0.5f).setEasePunch();
 
         gunController.Reload(reloadEfficiencyPercentage * precision.Value.awardFactor);
         animator.OnReload(gunController.stats);

--- a/Assets/Scripts/Augment/AugmentImplementations/DDRBodyAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/DDRBodyAnimator.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class DDRBodyAnimator : AugmentAnimator
 {
     private Animator animator;
-    public override void OnFire(int remainingAmmo)
+    public override void OnFire(GunStats stats)
     {
         animator.SetTrigger("Vibrate");
     }
@@ -17,7 +17,7 @@ public class DDRBodyAnimator : AugmentAnimator
             Debug.Log("Dance Body missing Animator");
     }
 
-    public override void OnReload(int ammo)
+    public override void OnReload(GunStats stats)
     {
         animator.SetTrigger("Vibrate");
     }

--- a/Assets/Scripts/Augment/AugmentImplementations/Hat/HatBarrelModel.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Hat/HatBarrelModel.cs
@@ -33,23 +33,23 @@ public class HatBarrelModel : AugmentAnimator
         }
     }
 
-    public override void OnReload(int ammo)
+    public override void OnReload(GunStats stats)
     {
         bullet.SetActive(true);
-        for (int i = 0; i < ammo; i++)
+        for (int i = 0; i < stats.Ammo; i++)
         {
             ammunition[i].SetActive(true);
         }
     }
 
-    public override void OnFire(int remainingAmmo)
+    public override void OnFire(GunStats stats)
     {
         animator.SetTrigger("Fire");
-        for (int i = remainingAmmo; i < magazineSize; i++)
+        for (int i = stats.Ammo; i < magazineSize; i++)
         {
             ammunition[i].SetActive(false);
         }
-        if (remainingAmmo == 0)
+        if (stats.Ammo == 0)
         {
             ToggleBullet();
         }

--- a/Assets/Scripts/Augment/AugmentImplementations/Hat/HatBarrelModel.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Hat/HatBarrelModel.cs
@@ -24,6 +24,8 @@ public class HatBarrelModel : AugmentAnimator
 
     public override void OnInitialize(GunStats stats)
     {
+        if (ammunition.Count > 0)
+            return;
         animator.speed = Mathf.Max(stats.Firerate, 1f);
         magazineSize = stats.magazineSize;
         for (int i = 0; i < magazineSize; i++)

--- a/Assets/Scripts/Augment/AugmentImplementations/Hat/MeshProjectileController.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Hat/MeshProjectileController.cs
@@ -41,6 +41,7 @@ public class MeshProjectileController : ProjectileController
 
     [FormerlySerializedAs("hatVfx")] [SerializeField]
     private VisualEffect vfx;
+    public VisualEffect Vfx => vfx;
 
     [Header("Ricochet")]
 

--- a/Assets/Scripts/Augment/AugmentImplementations/Hat/MeshProjectileController.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Hat/MeshProjectileController.cs
@@ -74,7 +74,7 @@ public class MeshProjectileController : ProjectileController
 
     protected override void OnReload(GunStats gunstats)
     {
-        animator.OnReload(gunstats.Ammo);
+        animator.OnReload(gunstats);
     }
 
     public override void InitializeProjectile(GunStats stats)
@@ -82,7 +82,7 @@ public class MeshProjectileController : ProjectileController
         loadedProjectile = new ProjectileState(stats, projectileOutput);
         loadedProjectile.maxDistance = maxDistance;
 
-        animator.OnFire(stats.Ammo);
+        animator.OnFire(stats);
     }
 
     private void FireProjectile()

--- a/Assets/Scripts/Augment/AugmentImplementations/LawnMower.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/LawnMower.cs
@@ -33,6 +33,7 @@ public class LawnMower : GunBody
     [SerializeField]
     private LineRenderer handString;
     private Animator handAnimator;
+    public Transform LineHoldingPoint;
 
     [Header("Material parameters")]
     [SerializeField]
@@ -65,16 +66,21 @@ public class LawnMower : GunBody
         playerHand.gameObject.SetActive(true);
         playerHand.SetPlayer(gunController.player);
         handAnimator = GetComponent<Animator>();
+        LineHoldingPoint = playerHand.HoldingPoint;
         handString.gameObject.SetActive(true);
+
         if (!MatchController.Singleton)
             return;
-        MatchController.Singleton.onRoundEnd += DisableLine; 
+        MatchController.Singleton.onRoundEnd += DisableLine;
+
+        if (gunController.player.GunOrigin.TryGetComponent(out GunController gunControllerDisplay))
+            gunControllerDisplay.GetComponentInChildren<LawnMower>().LineHoldingPoint = gunController.player.PlayerIK.LeftHandIKTransform;
     }
 
-    private void Update()
+    private void LateUpdate()
     {
         handString.SetPosition(0, lineStart.position);
-        handString.SetPosition(1, playerHand.HoldingPoint.position);
+        handString.SetPosition(1, LineHoldingPoint.position);
     }
 
     private void Fire(GunStats stats)

--- a/Assets/Scripts/Augment/AugmentImplementations/MowerAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/MowerAnimator.cs
@@ -12,6 +12,7 @@ public class MowerAnimator : AugmentAnimator
     private Animator handAnimator;
     [SerializeField]
     private ParticleSystem exhaustParticles;
+
     public override void OnFire(GunStats stats)
     {
         animator.SetTrigger("PistonPump");

--- a/Assets/Scripts/Augment/AugmentImplementations/MowerAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/MowerAnimator.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MowerAnimator : AugmentAnimator
+{
+    [SerializeField]
+    private LineRenderer handString;
+    [SerializeField]
+    private Animator animator;
+    [SerializeField]
+    private Animator handAnimator;
+    [SerializeField]
+    private ParticleSystem exhaustParticles;
+    public override void OnFire(GunStats stats)
+    {
+        animator.SetTrigger("PistonPump");
+        handAnimator.SetTrigger("Pull");
+    }
+
+    public override void OnInitialize(GunStats stats)
+    {
+        handString.gameObject.SetActive(true);
+    }
+
+    public override void OnReload(GunStats stats)
+    {
+        exhaustParticles.Play();
+    }
+}

--- a/Assets/Scripts/Augment/AugmentImplementations/MowerAnimator.cs.meta
+++ b/Assets/Scripts/Augment/AugmentImplementations/MowerAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77092469685134548aad694f939fb68c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Augment/AugmentImplementations/PlaceholderFiringAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/PlaceholderFiringAnimator.cs
@@ -3,9 +3,9 @@ using UnityEngine;
 public class PlaceholderFiringAnimator : AugmentAnimator
 {
     public override void OnInitialize(GunStats stats) { }
-    public override void OnReload(int ammo) { }
+    public override void OnReload(GunStats stats) { }
 
-    public override void OnFire(int remainingAmmo)
+    public override void OnFire(GunStats stats)
     {
         OnFireAnimationEnd?.Invoke();
     }

--- a/Assets/Scripts/Augment/AugmentImplementations/Revolver.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Revolver.cs
@@ -40,13 +40,20 @@ public class Revolver : GunBody
         if (extension)
             extension.transform.SetParent(attachmentSite, true);
 
-
         animator.SetTrigger("Reload");
+        gunController.onReload.Invoke(stats);
     }
 
     public void TriggerSteam()
     {
         steamParticles.Play();
+    }
+
+    public void ToggleArm()
+    {
+        if (!playerHand)
+            return;
+        playerHand.gameObject.SetActive(!playerHand.gameObject.activeInHierarchy);
     }
 
     public void ResetReload()
@@ -55,7 +62,6 @@ public class Revolver : GunBody
             barrel.transform.SetParent(gunController.transform, true);
         if (extension)
             extension.transform.SetParent(gunController.transform, true);
-
         gunController.Reload(reloadEfficiencyPercentage);
     }
 

--- a/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
@@ -38,7 +38,7 @@ public class RevolverAnimator : AugmentAnimator
         extension = transform.parent.gameObject.GetComponentInChildren<GunExtension>();
         if (extension)
             extension.transform.SetParent(attachmentSite, true);
-        Debug.Log("Reload called");
+
         animator.SetTrigger("Reload");
     }
 }

--- a/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
@@ -19,7 +19,6 @@ public class RevolverAnimator : AugmentAnimator
     {
         animator = GetComponent<Animator>();
         var playerHand = GetComponentInChildren<PlayerHand>(includeInactive: true);
-        //playerHand.transform.SetParent(null);
         Destroy(playerHand);
         if (!animator)
             Debug.Log("Revolver Body missing Animator");

--- a/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
@@ -10,16 +10,16 @@ public class RevolverAnimator : AugmentAnimator
     private Transform attachmentSite;
     private GunBarrel barrel;
     private GunExtension extension;
-    public override void OnFire(GunStats stats)
-    {
 
-    }
+    public override void OnFire(GunStats stats){}
 
     public override void OnInitialize(GunStats stats)
     {
         animator = GetComponent<Animator>();
         var playerHand = GetComponentInChildren<PlayerHand>(includeInactive: true);
         Destroy(playerHand);
+        barrel = transform.parent.gameObject.GetComponentInChildren<GunBarrel>();
+        extension = transform.parent.gameObject.GetComponentInChildren<GunExtension>();
         if (!animator)
             Debug.Log("Revolver Body missing Animator");
     }
@@ -30,11 +30,9 @@ public class RevolverAnimator : AugmentAnimator
         if (!canReload)
             return;
 
-        barrel = transform.parent.gameObject.GetComponentInChildren<GunBarrel>();
         if (barrel)
             barrel.transform.SetParent(attachmentSite, true);
 
-        extension = transform.parent.gameObject.GetComponentInChildren<GunExtension>();
         if (extension)
             extension.transform.SetParent(attachmentSite, true);
 

--- a/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
@@ -19,7 +19,7 @@ public class RevolverAnimator : AugmentAnimator
     {
         animator = GetComponent<Animator>();
         var playerHand = GetComponentInChildren<PlayerHand>(includeInactive: true);
-        playerHand.transform.SetParent(null);
+        //playerHand.transform.SetParent(null);
         Destroy(playerHand);
         if (!animator)
             Debug.Log("Revolver Body missing Animator");

--- a/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RevolverAnimator : AugmentAnimator
+{
+    private Animator animator;
+    private bool canReload = false;
+    [SerializeField]
+    private Transform attachmentSite;
+    private GunBarrel barrel;
+    private GunExtension extension;
+    public override void OnFire(GunStats stats)
+    {
+
+    }
+
+    public override void OnInitialize(GunStats stats)
+    {
+        animator = GetComponent<Animator>();
+        var playerHand = GetComponentInChildren<PlayerHand>(includeInactive: true);
+        playerHand.transform.SetParent(null);
+        Destroy(playerHand);
+        if (!animator)
+            Debug.Log("Revolver Body missing Animator");
+    }
+
+    public override void OnReload(GunStats stats)
+    {
+        canReload = !canReload;
+        if (!canReload)
+            return;
+
+        barrel = transform.parent.gameObject.GetComponentInChildren<GunBarrel>();
+        if (barrel)
+            barrel.transform.SetParent(attachmentSite, true);
+
+        extension = transform.parent.gameObject.GetComponentInChildren<GunExtension>();
+        if (extension)
+            extension.transform.SetParent(attachmentSite, true);
+        Debug.Log("Reload called");
+        animator.SetTrigger("Reload");
+    }
+}

--- a/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs.meta
+++ b/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3aa4de144f24b42468ea229da449236f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Augment/BulletController.cs
+++ b/Assets/Scripts/Augment/BulletController.cs
@@ -19,6 +19,7 @@ public class BulletController : ProjectileController
 
     [SerializeField]
     private VisualEffect trail;
+    public GameObject Trail => trail.gameObject;
 
     [SerializeField]
     private VisualEffect flash;
@@ -131,6 +132,11 @@ public class BulletController : ProjectileController
         }
         // Play the flash and trail
         trail.SendEvent("OnPlay");
+        flash.SendEvent("OnPlay");
+    }
+
+    public void PlayMuzzleFlash(GunStats stats)
+    {
         flash.SendEvent("OnPlay");
     }
 

--- a/Assets/Scripts/Augment/BulletController.cs
+++ b/Assets/Scripts/Augment/BulletController.cs
@@ -54,12 +54,12 @@ public class BulletController : ProjectileController
 
     protected override void OnReload(GunStats gunstats)
     {
-        animator.OnReload(gunstats.Ammo);
+        animator.OnReload(gunstats);
     }
 
     public override void InitializeProjectile(GunStats stats)
     {
-        animator.OnFire(stats.Ammo);
+        animator.OnFire(stats);
 
         for (int k = 0; k < stats.ProjectilesPerShot; k++)
         {

--- a/Assets/Scripts/Augment/GunController.cs
+++ b/Assets/Scripts/Augment/GunController.cs
@@ -35,6 +35,7 @@ public class GunController : MonoBehaviour
     public GunEvent onReload;
     public GunEvent onFire;
     public GunEvent onInitializeGun;
+    public GunEvent onInitializeBullet;
 
     private void FixedUpdate()
     {
@@ -81,5 +82,6 @@ public class GunController : MonoBehaviour
         projectile.projectileRotation = Quaternion.AngleAxis(Vector3.Angle(defaultOutput, lerpedOutput), Vector3.Cross(defaultOutput, lerpedOutput));
 
         projectile.InitializeProjectile(stats);
+        onInitializeBullet?.Invoke(stats);
     }
 }

--- a/Assets/Scripts/Augment/GunController.cs
+++ b/Assets/Scripts/Augment/GunController.cs
@@ -61,6 +61,17 @@ public class GunController : MonoBehaviour
         onReload?.Invoke(stats);
     }
 
+    private void Start()
+    {
+        if (HasRecoil)
+            onFire += PlayRecoil;
+    }
+
+    public void PlayRecoil(GunStats stats)
+    {
+        gameObject.LeanMoveLocalZ(0.3f, 0.2f).setEasePunch();
+    }
+
     private void FireGun()
     {
         if (stats.Ammo <= 0)
@@ -71,9 +82,7 @@ public class GunController : MonoBehaviour
         stats.Ammo = Mathf.Clamp(stats.Ammo - 1, 0, stats.magazineSize);
 
         onFire?.Invoke(stats);
-        if (HasRecoil)
-            gameObject.LeanMoveLocalZ(0.3f, 0.2f).setEasePunch();
-
+            
         // Aim at target but lerp in original direction if target is close
         Vector3 targetedOutput = (target - projectile.projectileOutput.position).normalized;
         Vector3 defaultOutput = projectile.projectileOutput.forward;

--- a/Assets/Scripts/Augment/GunFactory.cs
+++ b/Assets/Scripts/Augment/GunFactory.cs
@@ -44,11 +44,14 @@ public class GunFactory : MonoBehaviour
         if (displayGun.gunController.HasRecoil)
             firstPersonGunController.onFire += displayGun.gunController.PlayRecoil;
 
-        if (!(displayGun.gunController.projectile.GetType() == typeof(BulletController)))
-            return gun;
+        if (displayGun.gunController.projectile.GetType() == typeof(BulletController))
+        {
+            ((BulletController) gun.GetComponent<GunFactory>().gunController.projectile).Trail.layer = 0;
+            firstPersonGunController.onFire += ((BulletController)displayGun.gunController.projectile).PlayMuzzleFlash;
+        }
 
-        ((BulletController)gun.GetComponent<GunFactory>().gunController.projectile).Trail.layer = 0;
-        firstPersonGunController.onFire += ((BulletController) displayGun.gunController.projectile).PlayMuzzleFlash;
+        if (displayGun.gunController.projectile.GetType() == typeof(MeshProjectileController))
+            ((MeshProjectileController) gun.GetComponent<GunFactory>().gunController.projectile).Vfx.gameObject.layer = 0;
 
         return gun;
     }

--- a/Assets/Scripts/Augment/GunFactory.cs
+++ b/Assets/Scripts/Augment/GunFactory.cs
@@ -26,7 +26,7 @@ public class GunFactory : MonoBehaviour
         displayGun.Barrel = barrelPrefab;
         displayGun.Extension = extensionPrefab;
         displayGun.InitializeGun();
-        //owner.GunOrigin.SetParent(owner.GunHolder);
+
         var cullingLayerDisplay = LayerMask.NameToLayer("Player " + owner.inputManager.playerInput.playerIndex);
         SetGunLayer(displayGun, cullingLayerDisplay);
 
@@ -39,7 +39,6 @@ public class GunFactory : MonoBehaviour
             firstPersonGunController.onReload += animation.OnReload;
         }
 
-        firstPersonGunController.LeftHandTarget = displayGun.gunController.LeftHandTarget;
         firstPersonGunController.RightHandTarget = displayGun.gunController.RightHandTarget;
 
         if (displayGun.gunController.HasRecoil)

--- a/Assets/Scripts/Augment/GunFactory.cs
+++ b/Assets/Scripts/Augment/GunFactory.cs
@@ -18,6 +18,40 @@ public class GunFactory : MonoBehaviour
         // Initialize everything
         gun.GetComponent<GunFactory>().InitializeGun(owner);
 
+        var cullingLayer = LayerMask.NameToLayer("Gun " + owner.inputManager.playerInput.playerIndex);
+        gun.layer = cullingLayer;
+
+        var childrenMeshRenderer = gun.GetComponentsInChildren<MeshRenderer>(includeInactive: true);
+        foreach (var child in childrenMeshRenderer)
+        {
+            child.gameObject.layer = cullingLayer;
+        }
+        var childrenSkinnedMeshRenderer = gun.GetComponentsInChildren<MeshRenderer>(includeInactive: true);
+        foreach (var child in childrenSkinnedMeshRenderer)
+        {
+            child.gameObject.layer = cullingLayer;
+        }
+
+        GunFactory displayGun = owner.GunHolder.GetComponent<GunFactory>();
+        displayGun.Body = bodyPrefab;
+        displayGun.Barrel = barrelPrefab;
+        displayGun.Extension = extensionPrefab;
+        displayGun.InitializeGun();
+
+        var cullingLayerDisplay = LayerMask.NameToLayer("Player " + owner.inputManager.playerInput.playerIndex);
+        displayGun.gameObject.layer = cullingLayerDisplay;
+
+        var childrenDisplayMeshRenderer = displayGun.GetComponentsInChildren<MeshRenderer>(includeInactive: true);
+        foreach (var child in childrenDisplayMeshRenderer)
+        {
+            child.gameObject.layer = cullingLayerDisplay;
+        }
+        var childrenDisplaySkinnedMeshRenderer = displayGun.GetComponentsInChildren<SkinnedMeshRenderer>(includeInactive: true);
+        foreach (var child in childrenDisplaySkinnedMeshRenderer)
+        {
+            child.gameObject.layer = cullingLayerDisplay;
+        }
+
         return gun;
     }
 

--- a/Assets/Scripts/Augment/GunFactory.cs
+++ b/Assets/Scripts/Augment/GunFactory.cs
@@ -21,12 +21,12 @@ public class GunFactory : MonoBehaviour
         var cullingLayer = LayerMask.NameToLayer("Gun " + owner.inputManager.playerInput.playerIndex);
         SetGunLayer(gun.GetComponent<GunFactory>(), cullingLayer);
 
-        GunFactory displayGun = owner.GunHolder.GetComponent<GunFactory>();
+        GunFactory displayGun = owner.GunOrigin.GetComponent<GunFactory>();
         displayGun.Body = bodyPrefab;
         displayGun.Barrel = barrelPrefab;
         displayGun.Extension = extensionPrefab;
         displayGun.InitializeGun();
-        owner.GunHolder.SetParent(parent);
+        //owner.GunOrigin.SetParent(owner.GunHolder);
         var cullingLayerDisplay = LayerMask.NameToLayer("Player " + owner.inputManager.playerInput.playerIndex);
         SetGunLayer(displayGun, cullingLayerDisplay);
 
@@ -39,12 +39,15 @@ public class GunFactory : MonoBehaviour
             firstPersonGunController.onReload += animation.OnReload;
         }
 
+        firstPersonGunController.LeftHandTarget = displayGun.gunController.LeftHandTarget;
+        firstPersonGunController.RightHandTarget = displayGun.gunController.RightHandTarget;
+
         if (displayGun.gunController.HasRecoil)
             firstPersonGunController.onFire += displayGun.gunController.PlayRecoil;
 
         if (!(displayGun.gunController.projectile.GetType() == typeof(BulletController)))
             return gun;
-        // TODO: Refactor BulletController so this badness isn't needed
+
         ((BulletController)gun.GetComponent<GunFactory>().gunController.projectile).Trail.layer = 0;
         firstPersonGunController.onFire += ((BulletController) displayGun.gunController.projectile).PlayMuzzleFlash;
 

--- a/Assets/Scripts/Augment/GunFactory.cs
+++ b/Assets/Scripts/Augment/GunFactory.cs
@@ -19,18 +19,7 @@ public class GunFactory : MonoBehaviour
         gun.GetComponent<GunFactory>().InitializeGun(owner);
 
         var cullingLayer = LayerMask.NameToLayer("Gun " + owner.inputManager.playerInput.playerIndex);
-        gun.layer = cullingLayer;
-
-        var childrenMeshRenderer = gun.GetComponentsInChildren<MeshRenderer>(includeInactive: true);
-        foreach (var child in childrenMeshRenderer)
-        {
-            child.gameObject.layer = cullingLayer;
-        }
-        var childrenSkinnedMeshRenderer = gun.GetComponentsInChildren<MeshRenderer>(includeInactive: true);
-        foreach (var child in childrenSkinnedMeshRenderer)
-        {
-            child.gameObject.layer = cullingLayer;
-        }
+        SetGunLayer(gun.GetComponent<GunFactory>(), cullingLayer);
 
         GunFactory displayGun = owner.GunHolder.GetComponent<GunFactory>();
         displayGun.Body = bodyPrefab;
@@ -39,20 +28,35 @@ public class GunFactory : MonoBehaviour
         displayGun.InitializeGun();
 
         var cullingLayerDisplay = LayerMask.NameToLayer("Player " + owner.inputManager.playerInput.playerIndex);
-        displayGun.gameObject.layer = cullingLayerDisplay;
+        SetGunLayer(displayGun, cullingLayerDisplay);
 
-        var childrenDisplayMeshRenderer = displayGun.GetComponentsInChildren<MeshRenderer>(includeInactive: true);
-        foreach (var child in childrenDisplayMeshRenderer)
+        var firstPersonGunController = gun.GetComponent<GunFactory>().gunController;
+        var gunAnimations = displayGun.GetComponentsInChildren<AugmentAnimator>(includeInactive: true);
+        foreach (var animation in gunAnimations)
         {
-            child.gameObject.layer = cullingLayerDisplay;
-        }
-        var childrenDisplaySkinnedMeshRenderer = displayGun.GetComponentsInChildren<SkinnedMeshRenderer>(includeInactive: true);
-        foreach (var child in childrenDisplaySkinnedMeshRenderer)
-        {
-            child.gameObject.layer = cullingLayerDisplay;
+            animation.OnInitialize(firstPersonGunController.stats);
+            firstPersonGunController.onFire += animation.OnFire;
+            firstPersonGunController.onReload += animation.OnReload;
         }
 
         return gun;
+    }
+
+    private static void SetGunLayer(GunFactory gunFactory, int cullingLayer)
+    {
+        gunFactory.gameObject.layer = cullingLayer;
+
+        var childrenDisplayMeshRenderer = gunFactory.GetComponentsInChildren<MeshRenderer>(includeInactive: true);
+        foreach (var child in childrenDisplayMeshRenderer)
+        {
+            child.gameObject.layer = cullingLayer;
+        }
+
+        var childrenDisplaySkinnedMeshRenderer = gunFactory.GetComponentsInChildren<SkinnedMeshRenderer>(includeInactive: true);
+        foreach (var child in childrenDisplaySkinnedMeshRenderer)
+        {
+            child.gameObject.layer = cullingLayer;
+        }
     }
 
     public static GameObject InstantiateGun(Item bodyPrefab, Item barrelPrefab, Item extensionPrefab, PlayerManager owner, RectTransform parent)
@@ -97,7 +101,7 @@ public class GunFactory : MonoBehaviour
     [SerializeField]
     public Item Extension;
 
-    private GunController gunController;
+    public GunController gunController { private set; get; }
 
 #if UNITY_EDITOR
     private void Start()

--- a/Assets/Scripts/Augment/GunFactory.cs
+++ b/Assets/Scripts/Augment/GunFactory.cs
@@ -26,7 +26,7 @@ public class GunFactory : MonoBehaviour
         displayGun.Barrel = barrelPrefab;
         displayGun.Extension = extensionPrefab;
         displayGun.InitializeGun();
-
+        owner.GunHolder.SetParent(parent);
         var cullingLayerDisplay = LayerMask.NameToLayer("Player " + owner.inputManager.playerInput.playerIndex);
         SetGunLayer(displayGun, cullingLayerDisplay);
 
@@ -39,15 +39,14 @@ public class GunFactory : MonoBehaviour
             firstPersonGunController.onReload += animation.OnReload;
         }
 
+        if (displayGun.gunController.HasRecoil)
+            firstPersonGunController.onFire += displayGun.gunController.PlayRecoil;
+
         if (!(displayGun.gunController.projectile.GetType() == typeof(BulletController)))
             return gun;
-
-        // TODO: Maybe use the same smoke trail from first-person gun? This operation currently double calculations for every shot 
-        firstPersonGunController.onInitializeBullet += ((BulletController)displayGun.gunController.projectile).InitializeProjectile;
-
-        // Unfinished attempt at reusing texture, might have to just manually apply layer instead.
-        //firstPersonGunController.onInitializeBullet += ((BulletController) displayGun.gunController.projectile).PlayCachedVFX;
-        //((BulletController) displayGun.gunController.projectile).RealBullet = (BulletController) firstPersonGunController.projectile;
+        // TODO: Refactor BulletController so this badness isn't needed
+        ((BulletController)gun.GetComponent<GunFactory>().gunController.projectile).Trail.layer = 0;
+        firstPersonGunController.onFire += ((BulletController) displayGun.gunController.projectile).PlayMuzzleFlash;
 
         return gun;
     }

--- a/Assets/Scripts/Augment/GunFactory.cs
+++ b/Assets/Scripts/Augment/GunFactory.cs
@@ -39,6 +39,16 @@ public class GunFactory : MonoBehaviour
             firstPersonGunController.onReload += animation.OnReload;
         }
 
+        if (!(displayGun.gunController.projectile.GetType() == typeof(BulletController)))
+            return gun;
+
+        // TODO: Maybe use the same smoke trail from first-person gun? This operation currently double calculations for every shot 
+        firstPersonGunController.onInitializeBullet += ((BulletController)displayGun.gunController.projectile).InitializeProjectile;
+
+        // Unfinished attempt at reusing texture, might have to just manually apply layer instead.
+        //firstPersonGunController.onInitializeBullet += ((BulletController) displayGun.gunController.projectile).PlayCachedVFX;
+        //((BulletController) displayGun.gunController.projectile).RealBullet = (BulletController) firstPersonGunController.projectile;
+
         return gun;
     }
 
@@ -46,17 +56,12 @@ public class GunFactory : MonoBehaviour
     {
         gunFactory.gameObject.layer = cullingLayer;
 
-        var childrenDisplayMeshRenderer = gunFactory.GetComponentsInChildren<MeshRenderer>(includeInactive: true);
-        foreach (var child in childrenDisplayMeshRenderer)
+        var children = gunFactory.GetComponentsInChildren<Transform>(includeInactive: true);
+        foreach (var child in children)
         {
             child.gameObject.layer = cullingLayer;
         }
 
-        var childrenDisplaySkinnedMeshRenderer = gunFactory.GetComponentsInChildren<SkinnedMeshRenderer>(includeInactive: true);
-        foreach (var child in childrenDisplaySkinnedMeshRenderer)
-        {
-            child.gameObject.layer = cullingLayer;
-        }
     }
 
     public static GameObject InstantiateGun(Item bodyPrefab, Item barrelPrefab, Item extensionPrefab, PlayerManager owner, RectTransform parent)

--- a/Assets/Scripts/Augment/GunFactory.cs
+++ b/Assets/Scripts/Augment/GunFactory.cs
@@ -30,7 +30,7 @@ public class GunFactory : MonoBehaviour
         var cullingLayerDisplay = LayerMask.NameToLayer("Player " + owner.inputManager.playerInput.playerIndex);
         SetGunLayer(displayGun, cullingLayerDisplay);
 
-        var firstPersonGunController = gun.GetComponent<GunFactory>().gunController;
+        var firstPersonGunController = gun.GetComponent<GunFactory>().GunController;
         var gunAnimations = displayGun.GetComponentsInChildren<AugmentAnimator>(includeInactive: true);
         foreach (var animation in gunAnimations)
         {
@@ -39,19 +39,19 @@ public class GunFactory : MonoBehaviour
             firstPersonGunController.onReload += animation.OnReload;
         }
 
-        firstPersonGunController.RightHandTarget = displayGun.gunController.RightHandTarget;
+        firstPersonGunController.RightHandTarget = displayGun.GunController.RightHandTarget;
 
-        if (displayGun.gunController.HasRecoil)
-            firstPersonGunController.onFire += displayGun.gunController.PlayRecoil;
+        if (displayGun.GunController.HasRecoil)
+            firstPersonGunController.onFire += displayGun.GunController.PlayRecoil;
 
-        if (displayGun.gunController.projectile.GetType() == typeof(BulletController))
+        if (displayGun.GunController.projectile.GetType() == typeof(BulletController))
         {
-            ((BulletController) gun.GetComponent<GunFactory>().gunController.projectile).Trail.layer = 0;
-            firstPersonGunController.onFire += ((BulletController)displayGun.gunController.projectile).PlayMuzzleFlash;
+            ((BulletController) gun.GetComponent<GunFactory>().GunController.projectile).Trail.layer = 0;
+            firstPersonGunController.onFire += ((BulletController)displayGun.GunController.projectile).PlayMuzzleFlash;
         }
 
-        if (displayGun.gunController.projectile.GetType() == typeof(MeshProjectileController))
-            ((MeshProjectileController) gun.GetComponent<GunFactory>().gunController.projectile).Vfx.gameObject.layer = 0;
+        if (displayGun.GunController.projectile.GetType() == typeof(MeshProjectileController))
+            ((MeshProjectileController) gun.GetComponent<GunFactory>().GunController.projectile).Vfx.gameObject.layer = 0;
 
         return gun;
     }
@@ -109,8 +109,8 @@ public class GunFactory : MonoBehaviour
 
     [SerializeField]
     public Item Extension;
-
-    public GunController gunController { private set; get; }
+    private GunController gunController;
+    public GunController GunController => gunController;
 
 #if UNITY_EDITOR
     private void Start()

--- a/Assets/Scripts/Control&Input/PlayerMovement.cs
+++ b/Assets/Scripts/Control&Input/PlayerMovement.cs
@@ -77,6 +77,8 @@ public class PlayerMovement : MonoBehaviour
     [Header("State")]
     [SerializeField]
     private float crouchedHeightOffset = 0.3f;
+    [SerializeField]
+    private float crouchedHeightGunOffset = 0.28f;
 
     [SerializeField]
     private float airThreshold = 0.4f;
@@ -90,9 +92,12 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField]
     private Animator animator;
 
+    private GameObject gunHolder;
+
     private const float MarsGravity = 3.7f;
 
     private float localCameraHeight;
+    private float localGunHolderHeight;
 
     private Vector2 aimAngle = Vector2.zero;
 
@@ -117,6 +122,8 @@ public class PlayerMovement : MonoBehaviour
         inputManager.onCrouchPerformed += OnCrouch;
         inputManager.onCrouchCanceled += OnCrouch;
         localCameraHeight = inputManager.transform.localPosition.y;
+        gunHolder = GetComponent<PlayerManager>().GunHolder.gameObject;
+        localGunHolderHeight = gunHolder.transform.localPosition.y;
     }
 
     private void OnJump(InputAction.CallbackContext ctx)
@@ -144,6 +151,7 @@ public class PlayerMovement : MonoBehaviour
         {
             LeanTween.cancel(inputManager.gameObject);
             inputManager.transform.localPosition = new Vector3(inputManager.transform.localPosition.x, localCameraHeight, inputManager.transform.localPosition.z);
+            gunHolder.transform.localPosition = new Vector3(gunHolder.transform.localPosition.x, localGunHolderHeight, gunHolder.transform.localPosition.z);
         }
 
         if (ctx.performed)
@@ -161,6 +169,7 @@ public class PlayerMovement : MonoBehaviour
             animator.SetBool("Crouching", false);
             strafeForce = strafeForceGrounded;
             inputManager.gameObject.LeanMoveLocalY(localCameraHeight, 0.2f);
+            gunHolder.LeanMoveLocalY(localGunHolderHeight, 0.2f);
             isDashing = false;
             onLanding -= StartCrouch;
         }
@@ -172,6 +181,7 @@ public class PlayerMovement : MonoBehaviour
         animator.SetBool("Crouching", true);
         strafeForce = strafeForceCrouched;
         inputManager.gameObject.LeanMoveLocalY(localCameraHeight - crouchedHeightOffset, 0.2f);
+        gunHolder.LeanMoveLocalY(localGunHolderHeight - crouchedHeightGunOffset, 0.2f);
     }
 
     private void EnableDash()
@@ -249,7 +259,7 @@ public class PlayerMovement : MonoBehaviour
     {
         aimAngle += inputManager.lookInput * lookSpeed * Time.deltaTime;
         // Constrain aiming angle vertically and wrap horizontally.
-        aimAngle.y = Mathf.Clamp(aimAngle.y, -Mathf.PI / 2, Mathf.PI / 2);
+        aimAngle.y = Mathf.Clamp(aimAngle.y, -Mathf.PI / 2 + Mathf.Deg2Rad, Mathf.PI / 2 - Mathf.Deg2Rad);
         aimAngle.x = (aimAngle.x + Mathf.PI) % (2 * Mathf.PI) - Mathf.PI;
         // Rotate rigidbody.
         body.MoveRotation(Quaternion.AngleAxis(aimAngle.x * Mathf.Rad2Deg, Vector3.up));

--- a/Assets/Scripts/Control&Input/PlayerMovement.cs
+++ b/Assets/Scripts/Control&Input/PlayerMovement.cs
@@ -259,6 +259,9 @@ public class PlayerMovement : MonoBehaviour
     {
         aimAngle += inputManager.lookInput * lookSpeed * Time.deltaTime;
         // Constrain aiming angle vertically and wrap horizontally.
+        // + and - Mathf.Deg2Rad is offsetting with 1 degree in radians,
+        // which is neccesary to avoid IK shortest path slerping that causes aniamtions to break at exactly the halfway points.
+        // This is way more computationaly efficient than creating edgecase checks in IK with practically no gameplay impact
         aimAngle.y = Mathf.Clamp(aimAngle.y, -Mathf.PI / 2 + Mathf.Deg2Rad, Mathf.PI / 2 - Mathf.Deg2Rad);
         aimAngle.x = (aimAngle.x + Mathf.PI) % (2 * Mathf.PI) - Mathf.PI;
         // Rotate rigidbody.

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -36,6 +36,10 @@ public class PlayerManager : MonoBehaviour
     [SerializeField]
     private Item ammoMaskItem;
 
+    [SerializeField]
+    private Transform gunHolder;
+    public Transform GunHolder => gunHolder;
+
     [Header("Related objects")]
 
     public InputManager inputManager;

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -37,8 +37,9 @@ public class PlayerManager : MonoBehaviour
     private Item ammoMaskItem;
 
     [SerializeField]
-    private Transform gunHolder;
-    public Transform GunHolder => gunHolder;
+    public Transform GunHolder;
+    [SerializeField]
+    public Transform GunOrigin;
 
     [Header("Related objects")]
 
@@ -96,6 +97,12 @@ public class PlayerManager : MonoBehaviour
         audioSource = GetComponent<AudioSource>();
     }
 
+    private void Update()
+    {
+        if (GunHolder)
+            GunHolder.transform.forward = inputManager.transform.forward;
+    }
+
     void OnDamageTaken(HealthController healthController, float damage, DamageInfo info)
     {
         hudController.OnDamageTaken(damage, healthController.CurrentHealth, healthController.MaxHealth);
@@ -127,6 +134,7 @@ public class PlayerManager : MonoBehaviour
         playerIK.enabled = false;
         // TODO display guns falling to the floor
         gunController.gameObject.SetActive(false);
+        GunHolder.gameObject.SetActive(false);
         // Disable all colliders and physics
         // Ragdollify
         
@@ -272,7 +280,8 @@ public class PlayerManager : MonoBehaviour
         gunController.onReload += UpdateHudReload;
 
         playerIK.LeftHandIKTarget = gunController.LeftHandTarget;
-        playerIK.RightHandIKTarget = gunController.RightHandTarget;
+        if (gunController.RightHandTarget)
+            playerIK.RightHandIKTarget = gunController.RightHandTarget;
     }
 
     private void SetLayerOnSubtree(GameObject node, int layer)

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -58,6 +58,7 @@ public class PlayerManager : MonoBehaviour
 
     [SerializeField]
     private PlayerIK playerIK;
+    public PlayerIK PlayerIK => playerIK;
 
     [SerializeField]
     private float deathKnockbackForceMultiplier = 10;

--- a/Assets/Scripts/Utils/PlayerIK.cs
+++ b/Assets/Scripts/Utils/PlayerIK.cs
@@ -41,6 +41,13 @@ public class PlayerIK : MonoBehaviour
     [SerializeField]
     private float modelScaleOffset;
 
+    [SerializeField]
+    private Transform leftHandIKTransform;
+    public Transform LeftHandIKTransform => leftHandIKTransform;
+    [SerializeField]
+    private Transform rightHandIKTranform;
+    public Transform RightHandIKTransform => rightHandIKTranform;
+
     private void LateUpdate()
     {
         if (LeftHandIKTarget && LeftHandIKTarget.gameObject.activeInHierarchy)

--- a/Assets/Settings/URP_Renderer.asset
+++ b/Assets/Settings/URP_Renderer.asset
@@ -1,5 +1,47 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8486650985388516426
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3d386ba5cd94485973aee1479b272e, type: 3}
+  m_Name: RenderGun
+  m_EditorClassIdentifier: 
+  m_Active: 1
+  settings:
+    passTag: RenderGun
+    Event: 300
+    filterSettings:
+      RenderQueueType: 0
+      LayerMask:
+        serializedVersion: 2
+        m_Bits: 61440
+      PassNames: []
+    overrideMaterial: {fileID: 0}
+    overrideMaterialPassIndex: 0
+    overrideShader: {fileID: 0}
+    overrideShaderPassIndex: 0
+    overrideMode: 0
+    overrideDepthState: 1
+    depthCompareFunction: 4
+    enableWrite: 1
+    stencilSettings:
+      overrideStencilState: 0
+      stencilReference: 0
+      stencilCompareFunction: 8
+      passOperation: 0
+      failOperation: 0
+      zFailOperation: 0
+    cameraSettings:
+      overrideCamera: 0
+      restoreCamera: 1
+      offset: {x: 0, y: 0, z: 0, w: 0}
+      cameraFieldOfView: 60
 --- !u!114 &-1637506080213435590
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32,7 +74,9 @@ MonoBehaviour:
   - {fileID: -1637506080213435590}
   - {fileID: 7396890855850247264}
   - {fileID: 3994693275162390452}
-  m_RendererFeatureMap: 3afb555be56846e960044a010b09a766b42fb2745e007037
+  - {fileID: 7095047516156872019}
+  - {fileID: -8486650985388516426}
+  m_RendererFeatureMap: 3afb555be56846e960044a010b09a766b42fb2745e00703753450cf11fac7662b6db329be45b398a
   m_UseNativeRenderPass: 0
   postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
   xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
@@ -53,7 +97,7 @@ MonoBehaviour:
   m_AssetVersion: 2
   m_OpaqueLayerMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 2147483647
   m_TransparentLayerMask:
     serializedVersion: 2
     m_Bits: 4294967295
@@ -93,6 +137,48 @@ MonoBehaviour:
       normalBlend: 0
   m_CopyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
   m_DBufferClear: {fileID: 4800000, guid: f056d8bd2a1c7e44e9729144b4c70395, type: 3}
+--- !u!114 &7095047516156872019
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3d386ba5cd94485973aee1479b272e, type: 3}
+  m_Name: RenderObscuredGun
+  m_EditorClassIdentifier: 
+  m_Active: 1
+  settings:
+    passTag: RenderObscuredGun
+    Event: 300
+    filterSettings:
+      RenderQueueType: 0
+      LayerMask:
+        serializedVersion: 2
+        m_Bits: 61440
+      PassNames: []
+    overrideMaterial: {fileID: 2100000, guid: 8433c20840b9c9f4fb17f23a56da4dfa, type: 2}
+    overrideMaterialPassIndex: 0
+    overrideShader: {fileID: 0}
+    overrideShaderPassIndex: 0
+    overrideMode: 0
+    overrideDepthState: 1
+    depthCompareFunction: 5
+    enableWrite: 1
+    stencilSettings:
+      overrideStencilState: 0
+      stencilReference: 0
+      stencilCompareFunction: 8
+      passOperation: 0
+      failOperation: 0
+      zFailOperation: 0
+    cameraSettings:
+      overrideCamera: 0
+      restoreCamera: 1
+      offset: {x: 0, y: 0, z: 0, w: 0}
+      cameraFieldOfView: 60
 --- !u!114 &7396890855850247264
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Shaders/ddrShader.shadergraph
+++ b/Assets/Shaders/ddrShader.shadergraph
@@ -37,19 +37,7 @@
             "m_Id": "2e165fa22b95438b8d43d1dc09e68538"
         },
         {
-            "m_Id": "3a77ad0d1fcc452eba4020ea8c528531"
-        },
-        {
-            "m_Id": "fc05f6f61dda4ab2baa4780b81fcdfaf"
-        },
-        {
-            "m_Id": "2f437e9eace34a1c907e92bddeffa6a4"
-        },
-        {
             "m_Id": "ba65ec77cb1c4861a0b4893f987f9793"
-        },
-        {
-            "m_Id": "84b6150e9f1d4673a91385f53b5b42a9"
         },
         {
             "m_Id": "6220c9fe39b34b8b9040c9ebc7369df4"
@@ -594,19 +582,7 @@
                 "m_Id": "2e165fa22b95438b8d43d1dc09e68538"
             },
             {
-                "m_Id": "3a77ad0d1fcc452eba4020ea8c528531"
-            },
-            {
-                "m_Id": "fc05f6f61dda4ab2baa4780b81fcdfaf"
-            },
-            {
-                "m_Id": "2f437e9eace34a1c907e92bddeffa6a4"
-            },
-            {
                 "m_Id": "ba65ec77cb1c4861a0b4893f987f9793"
-            },
-            {
-                "m_Id": "84b6150e9f1d4673a91385f53b5b42a9"
             }
         ]
     },
@@ -697,21 +673,6 @@
         "z": 0.0,
         "w": 0.0
     },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "035ad18cc76546609615257ce461c96a",
-    "m_Id": 0,
-    "m_DisplayName": "Smoothness",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Smoothness",
-    "m_StageCapability": 2,
-    "m_Value": 0.5,
-    "m_DefaultValue": 0.5,
     "m_Labels": []
 }
 
@@ -895,21 +856,6 @@
     },
     "m_Labels": [],
     "m_Space": 0
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "149684dbced74bf1bbdaf5841de069b1",
-    "m_Id": 0,
-    "m_DisplayName": "Ambient Occlusion",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Occlusion",
-    "m_StageCapability": 2,
-    "m_Value": 1.0,
-    "m_DefaultValue": 1.0,
-    "m_Labels": []
 }
 
 {
@@ -1248,40 +1194,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "2f437e9eace34a1c907e92bddeffa6a4",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Smoothness",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "035ad18cc76546609615257ce461c96a"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Smoothness"
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "313b7653f5044c658cfe2108e123268c",
     "m_Id": 0,
@@ -1411,40 +1323,6 @@
             "m_Id": "f916a5e918664db7855b05213dc888eb"
         }
     ]
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "3a77ad0d1fcc452eba4020ea8c528531",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.NormalTS",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "9ed03f5cd2bd453bb98c27b4c8ed0221"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.NormalTS"
 }
 
 {
@@ -2412,7 +2290,7 @@
     "m_ObjectId": "69446c418d5444468032deeec43a6232",
     "m_Datas": [],
     "m_ActiveSubTarget": {
-        "m_Id": "f568670db32b4fb58483a661dbf295ec"
+        "m_Id": "75940d3b3e3d491280c8c465cb592b1e"
     },
     "m_AllowMaterialOverride": false,
     "m_SurfaceType": 0,
@@ -2699,6 +2577,12 @@
 }
 
 {
+    "m_SGVersion": 2,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalUnlitSubTarget",
+    "m_ObjectId": "75940d3b3e3d491280c8c465cb592b1e"
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "75c9cd935d4e4b3eb9a481609231c462",
@@ -2869,40 +2753,6 @@
         "m_SerializableColors": []
     },
     "m_Unit": 1
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "84b6150e9f1d4673a91385f53b5b42a9",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Occlusion",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "149684dbced74bf1bbdaf5841de069b1"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Occlusion"
 }
 
 {
@@ -3339,30 +3189,6 @@
         "z": 0.0,
         "w": 0.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
-    "m_ObjectId": "9ed03f5cd2bd453bb98c27b4c8ed0221",
-    "m_Id": 0,
-    "m_DisplayName": "Normal (Tangent Space)",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "NormalTS",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": [],
-    "m_Space": 3
 }
 
 {
@@ -4533,16 +4359,6 @@
 }
 
 {
-    "m_SGVersion": 2,
-    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
-    "m_ObjectId": "f568670db32b4fb58483a661dbf295ec",
-    "m_WorkflowMode": 1,
-    "m_NormalDropOffSpace": 0,
-    "m_ClearCoat": false,
-    "m_BlendModePreserveSpecular": true
-}
-
-{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "f7687c865f454697b58987e1e52b4858",
@@ -4643,40 +4459,6 @@
 }
 
 {
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "fc05f6f61dda4ab2baa4780b81fcdfaf",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Metallic",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "feccdd13059c4857967a114da8f62277"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Metallic"
-}
-
-{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "fd142a034b5b4a9bb0b8b41f2cdd134f",
@@ -4702,20 +4484,5 @@
         "x": 0.0,
         "y": 1.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "feccdd13059c4857967a114da8f62277",
-    "m_Id": 0,
-    "m_DisplayName": "Metallic",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Metallic",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
 }
 


### PR DESCRIPTION
Major addition/rework for gun system
- First person guns and the gun other players see (display gun) are now decoupled
- Animations and effects like muzzle flash are now also decoupled
- Intensive runtime effects like trails and mesh projectiles are shared between both for the sake of efficiency 
- Add see-through effect when first person guns are inside geometry
![fancyCulling](https://github.com/hackerspace-ntnu/Red-Planet-Rampage/assets/54811121/ce944485-4e67-4030-a471-6ede91e67c2d)
- Add improved IK-animations for gun holding
![gunDecoulped](https://github.com/hackerspace-ntnu/Red-Planet-Rampage/assets/54811121/49a48af3-d841-464f-aaa3-aa6cf0fb82c0)

This makes it possible to add features like #345 and #329 + ironsight for all weapons, apply camera FOV and weapon FOV separately, and FINALLY fix the AimingEdgeCase quirk once an for all.

Code could be better in places like GunFactory, but would require an even larger refactoring (of ProjectileControllers), which I deem outside the scope of this PR