### PR TITLE
Fix mouse look jitter (partially) 

### DIFF
--- a/Assets/Prefabs/Input/PlayerInput.prefab
+++ b/Assets/Prefabs/Input/PlayerInput.prefab
@@ -79,7 +79,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerInput: {fileID: 0}
-  mouseLookScale: 0.1
+  mouseLookScale: 0.0015
   gamepadLookScale: 1
   ZoomActive: 0
 --- !u!20 &-8626314750790423148

--- a/Assets/Scripts/Control&Input/InputManager.cs
+++ b/Assets/Scripts/Control&Input/InputManager.cs
@@ -44,11 +44,13 @@ public class InputManager : MonoBehaviour
     public Vector2 lookInput { get; private set; } = Vector2.zero;
 
     [SerializeField]
-    private float mouseLookScale = 0.1f;
+    private float mouseLookScale = 0.02f;
     [SerializeField]
     private float gamepadLookScale = 0.75f;
 
     private bool isMouseAndKeyboard = false;
+    public bool IsMouseAndKeyboard => isMouseAndKeyboard;
+
     public bool ZoomActive = false;
 
     void Start()

--- a/Assets/Scripts/Control&Input/PlayerMovement.cs
+++ b/Assets/Scripts/Control&Input/PlayerMovement.cs
@@ -206,7 +206,7 @@ public class PlayerMovement : MonoBehaviour
             }
             StartCrouch();
         }
-            
+
         if (ctx.canceled)
         {
             animator.SetBool("Crouching", false);
@@ -216,7 +216,7 @@ public class PlayerMovement : MonoBehaviour
             isDashing = false;
             onLanding -= StartCrouch;
         }
-            
+
     }
 
     private void StartCrouch()
@@ -301,7 +301,8 @@ public class PlayerMovement : MonoBehaviour
     private void UpdateRotation()
     {
         var lookSpeedFactor = inputManager.ZoomActive ? LookSpeedZoom : lookSpeed;
-        aimAngle += inputManager.lookInput * lookSpeedFactor * Time.deltaTime;
+        var lookInput = inputManager.IsMouseAndKeyboard ? inputManager.lookInput : inputManager.lookInput * Time.deltaTime;
+        aimAngle += lookInput * lookSpeedFactor;
         // Constrain aiming angle vertically and wrap horizontally.
         // + and - Mathf.Deg2Rad is offsetting with 1 degree in radians,
         // which is neccesary to avoid IK shortest path slerping that causes aniamtions to break at exactly the halfway points.


### PR DESCRIPTION
Time.deltaTime should not be used for mouse delta since it already is a delta of pixels moved across the screen. Dampening mouse input by two orders of magnitude seems to work well for this input.

Background: I'm working on the game from a laptop where only the integrated graphics work, and with low framerate the current mouse input handling showed glaring faults, jittering painfully when I tried to aim (especially with ironsights).