### PR TITLE
Fix broken "rocket" jumping and player hand

### DIFF
--- a/Assets/Scripts/Augment/AugmentImplementations/Hat/MeshProjectileController.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Hat/MeshProjectileController.cs
@@ -162,13 +162,20 @@ public class MeshProjectileController : ProjectileController
 
         if (collisions.Length <= 0) return;
 
+
+
         if (collisions[0].TryGetComponent<HitboxController>(out HitboxController hitbox))
         {
+            var hasHitYourselfTooEarly = hitbox.health.Player == player && state.distanceTraveled < player.GunController.OutputTransitionDistance;
+            if (hasHitYourselfTooEarly)
+                return;
+
             OnColliderHit?.Invoke(collisions[0], ref state);
             OnHitboxCollision?.Invoke(hitbox, ref state);
             state.active = false;
             return;
         }
+
         if (shouldRicochet && state.distanceTraveled < maxDistanceBeforeStuck)
         {
             OnRicochet?.Invoke(collisions[0], ref state);

--- a/Assets/Scripts/Augment/PlayerHand.cs
+++ b/Assets/Scripts/Augment/PlayerHand.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class PlayerHand : MonoBehaviour
@@ -36,11 +34,12 @@ public class PlayerHand : MonoBehaviour
 
     private void DisableHand(PlayerManager killer, PlayerManager victim)
     {
-        gameObject.SetActive(false);
+        DisableHand();
     }
 
     private void DisableHand()
     {
-        gameObject.SetActive(false);
+        if (this && gameObject)
+            gameObject.SetActive(false);
     }
 }


### PR DESCRIPTION
- Rocket jumping was broken on gamepads because mesh projectiles hit your own aim assist hitbox when you aim downwards :pensive: 
- Player hand subscribes to ondeath and does not unsubscribe properly (although it looks to be doing so?)