### PR TITLE
Split round end delegate

### DIFF
--- a/Assets/Prefabs/Gamestate/MatchManager.prefab
+++ b/Assets/Prefabs/Gamestate/MatchManager.prefab
@@ -48,6 +48,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   roundLength: 180
+  delayBeforeRoundResults: 3
   roundEndDelay: 15
   biddingEndDelay: 1
   matchEndDelay: 5

--- a/Assets/Scripts/Augment/AugmentImplementations/LawnMower.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/LawnMower.cs
@@ -70,11 +70,14 @@ public class LawnMower : GunBody
         LineHoldingPoint = playerHandLeft.HoldingPoint;
         handString.gameObject.SetActive(true);
 
-        if (MatchController.Singleton)
-            MatchController.Singleton.onRoundEnd += DisableLine;
-
         if (gunController.Player.GunOrigin.TryGetComponent(out GunController gunControllerDisplay))
             gunControllerDisplay.GetComponentInChildren<LawnMower>().LineHoldingPoint = gunController.Player.PlayerIK.LeftHandIKTransform;
+    }
+
+    private void OnDestroy()
+    {
+        if (MatchController.Singleton)
+            MatchController.Singleton.onRoundEnd -= DisableLine;
     }
 
     private void LateUpdate()

--- a/Assets/Scripts/Augment/GunController.cs
+++ b/Assets/Scripts/Augment/GunController.cs
@@ -74,6 +74,9 @@ public class GunController : MonoBehaviour
 
     private void OnDestroy()
     {
+        if (!barrelAnimator)
+            return;
+
         if (HasRecoil)
             barrelAnimator.OnShotFiredAnimation -= PlayRecoil;
         barrelAnimator.OnShotFiredAnimation -= ShotFired;
@@ -147,7 +150,7 @@ public class GunController : MonoBehaviour
         // Output become camera when distance hit is closer than weaponOutput
         if (Player)
             projectile.projectileOutput = TargetIsTooClose ? Player.inputManager.transform : outputs[0];
-        
+
         // Aim at target but lerp in original direction if target is close
         Vector3 targetedOutput = (target - projectile.projectileOutput.position).normalized;
         Vector3 defaultOutput = projectile.projectileOutput.forward;

--- a/Assets/Scripts/Gamestate/MatchController.cs
+++ b/Assets/Scripts/Gamestate/MatchController.cs
@@ -31,6 +31,7 @@ public class MatchController : MonoBehaviour
 
     public delegate void MatchEvent();
 
+    public MatchEvent onOutcomeDecided;
     public MatchEvent onRoundEnd;
     public MatchEvent onRoundStart;
     public MatchEvent onBiddingStart;
@@ -39,6 +40,9 @@ public class MatchController : MonoBehaviour
     [Header("Timing")]
     [SerializeField]
     private float roundLength;
+
+    [SerializeField]
+    private float delayBeforeRoundResults = 3f;
 
     [SerializeField]
     private float roundEndDelay;
@@ -156,11 +160,21 @@ public class MatchController : MonoBehaviour
 
     public void EndActiveRound()
     {
-        onRoundEnd?.Invoke();
+        onOutcomeDecided?.Invoke();
         roundTimer.OnTimerUpdate -= AdjustMusic;
         roundTimer.OnTimerUpdate -= HUDTimerUpdate;
         roundTimer.OnTimerRunCompleted -= EndActiveRound;
         AssignRewards();
+        GlobalHUD.RoundTimer.enabled = false;
+        StartCoroutine(WaitAndShowResults());
+    }
+
+    private IEnumerator WaitAndShowResults()
+    {
+        // Delay first so we can see who killed who
+        yield return new WaitForSeconds(delayBeforeRoundResults);
+        // Scoreboard subscribes here
+        onRoundEnd?.Invoke();
     }
 
     public IEnumerator WaitAndStartNextBidding()

--- a/Assets/Scripts/Gamestate/PlayerFactory.cs
+++ b/Assets/Scripts/Gamestate/PlayerFactory.cs
@@ -30,6 +30,7 @@ public class PlayerFactory : MonoBehaviour
             SceneManager.LoadSceneAsync("Menu");
             return;
         }
+
         playerInputManagerController = PlayerInputManagerController.Singleton;
 
         // Enable splitscreen
@@ -38,6 +39,7 @@ public class PlayerFactory : MonoBehaviour
 
         if (!overrideMatchManager)
             return;
+
         playerInputManagerController.playerInputs.ForEach(input => input.GetComponent<PlayerIdentity>().resetItems());
         InstantiatePlayersFPS();
     }

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -99,7 +99,7 @@ public class PlayerManager : MonoBehaviour
     [SerializeField]
     private AudioGroup extraHitSounds;
 
-    void Start()
+    private void Start()
     {
         healthController = GetComponent<HealthController>();
         healthController.onDamageTaken += OnDamageTaken;
@@ -188,8 +188,11 @@ public class PlayerManager : MonoBehaviour
 
     void OnDestroy()
     {
-        healthController.onDamageTaken -= OnDamageTaken;
-        healthController.onDeath -= OnDeath;
+        if (healthController)
+        {
+            healthController.onDamageTaken -= OnDamageTaken;
+            healthController.onDeath -= OnDeath;
+        }
         if (gunController)
         {
             gunController.onFireStart -= UpdateAimTarget;

--- a/Assets/Scripts/Gamestate/Round.cs
+++ b/Assets/Scripts/Gamestate/Round.cs
@@ -63,7 +63,7 @@ public class Round
         {
             player.onDeath += OnDeath;
         }
-        MatchController.Singleton.onRoundEnd += OnRoundEnd;
+        MatchController.Singleton.onOutcomeDecided += OnOutcomeDecided;
     }
 
     public int KillCount(PlayerManager player)
@@ -79,13 +79,13 @@ public class Round
         return player == Winner;
     }
 
-    public void OnRoundEnd()
+    public void OnOutcomeDecided()
     {
         foreach (var player in players)
         {
             player.onDeath -= OnDeath;
         }
-        MatchController.Singleton.onRoundEnd -= OnRoundEnd;
+        MatchController.Singleton.onOutcomeDecided -= OnOutcomeDecided;
     }
 
     //TODO: Create struct for damagecontext with info about who was killed as parameter instead

--- a/Assets/Scripts/Scoreboard/ScoreboardManager.cs
+++ b/Assets/Scripts/Scoreboard/ScoreboardManager.cs
@@ -28,9 +28,6 @@ public class ScoreboardManager : MonoBehaviour
     [Range(0f, 5f)]
     private float newCrimeDelay = 1f;
 
-    [SerializeField]
-    private float delayBeforeMatchResults = 3f;
-
     private int step = 0;
     private int maxSteps = 0;
 
@@ -42,11 +39,11 @@ public class ScoreboardManager : MonoBehaviour
 
     // Refrences
     private MatchController matchController;
-    
+
 
     private void Awake()
     {
-    #region Singleton boilerplate
+        #region Singleton boilerplate
 
         if (Singleton != null)
         {
@@ -57,7 +54,7 @@ public class ScoreboardManager : MonoBehaviour
                 return;
             }
         }
-        
+
         Singleton = this;
 
         #endregion Singleton boilerplate    
@@ -99,10 +96,6 @@ public class ScoreboardManager : MonoBehaviour
 
     public IEnumerator ShowMatchResults()
     {
-        matchController.GlobalHUD.RoundTimer.enabled = false;
-        // Delay first so we can see who killed who
-        yield return new WaitForSeconds(delayBeforeMatchResults);
-
         // Animate the after battle scene
         Camera.main.transform.parent = transform;
         Camera.main.GetComponent<Animator>().SetTrigger("ScoreboardZoom");
@@ -116,7 +109,7 @@ public class ScoreboardManager : MonoBehaviour
         // Do not start adding crimes before the camera has finished the animation
         int delay = Mathf.RoundToInt(Camera.main.GetComponent<Animator>().runtimeAnimatorController.animationClips[0].length);
         yield return new WaitForSeconds(delay);
-        
+
         maxSteps = MaxNumberOfCrimes();
 
         StartCoroutine(NextCrime());


### PR DESCRIPTION
Several immersion-breaking actions were done upon deciding the victor of the round, which is a problem when we also wait for a little while before proceeding. Split the onRoundEnd delegate into two (naming can be discussed).

also made the return-to-menu behaviour default w/o regard to override toggle, since the override does things we shouldn't do when we don't _want_ to override :upside_down_face: (but this only caused issues once I had made the other changes in this branch)