### PR TITLE
Make it possible to choose no specular

### DIFF
--- a/Assets/Materials/AuctionHall/AuctionToon.mat
+++ b/Assets/Materials/AuctionHall/AuctionToon.mat
@@ -132,6 +132,7 @@ Material:
     - _Texture_Intensity: 1
     - _UVSec: 0
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/AuctionHall/Curtains.mat
+++ b/Assets/Materials/AuctionHall/Curtains.mat
@@ -129,8 +129,10 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
     - _UVSec: 0
     - _Use_Normal_Map: 1
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/ClockTower/ClockTower.mat
+++ b/Assets/Materials/ClockTower/ClockTower.mat
@@ -145,7 +145,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
     - _Use_Normal_Map: 1
+    - _Use_Specular: 1
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/Collectables/AmmoBoxMaterial.mat
+++ b/Assets/Materials/Collectables/AmmoBoxMaterial.mat
@@ -131,8 +131,10 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
     - _UVSec: 0
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/CraterTown/BankSign.mat
+++ b/Assets/Materials/CraterTown/BankSign.mat
@@ -58,6 +58,14 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _Metallic_Texture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Normal_Map:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _OcclusionMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -120,6 +128,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
+    - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
@@ -128,6 +139,7 @@ Material:
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _Specular: {r: 1, g: 1, b: 1, a: 1}
+    - _Texture_Tiling: {r: 1, g: 1, b: 0, a: 0}
   m_BuildTextureStacks: []
 --- !u!114 &3498790263109481780
 MonoBehaviour:

--- a/Assets/Materials/CraterTown/InhabitantDoorMaterial.mat
+++ b/Assets/Materials/CraterTown/InhabitantDoorMaterial.mat
@@ -130,6 +130,7 @@ Material:
     - _Surface: 0
     - _Texture_Intensity: 1
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/CraterTown/MetalHayBale.mat
+++ b/Assets/Materials/CraterTown/MetalHayBale.mat
@@ -58,6 +58,14 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _Metallic_Texture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Normal_Map:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _OcclusionMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -120,6 +128,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
+    - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/CraterTown/RedStreakedMetal.mat
+++ b/Assets/Materials/CraterTown/RedStreakedMetal.mat
@@ -130,6 +130,7 @@ Material:
     - _Surface: 0
     - _Texture_Intensity: 1
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/CraterTown/RustedStreakedWhiteMetal.mat
+++ b/Assets/Materials/CraterTown/RustedStreakedWhiteMetal.mat
@@ -141,7 +141,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/CraterTown/SaloonSign.mat
+++ b/Assets/Materials/CraterTown/SaloonSign.mat
@@ -58,6 +58,14 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _Metallic_Texture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Normal_Map:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _OcclusionMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -120,6 +128,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
+    - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
@@ -127,6 +138,7 @@ Material:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _Texture_Tiling: {r: 1, g: 1, b: 0, a: 0}
   m_BuildTextureStacks: []
 --- !u!114 &3498790263109481780
 MonoBehaviour:

--- a/Assets/Materials/CraterTown/WoodMaterial 1.mat
+++ b/Assets/Materials/CraterTown/WoodMaterial 1.mat
@@ -58,6 +58,14 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _Metallic_Texture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Normal_Map:
+        m_Texture: {fileID: 2800000, guid: b29d9fe74bc0f7d43a738f97c32013c3, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _OcclusionMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -120,6 +128,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
+    - _Use_Normal_Map: 1
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/CraterTown/WoodMaterial.mat
+++ b/Assets/Materials/CraterTown/WoodMaterial.mat
@@ -58,6 +58,14 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _Metallic_Texture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Normal_Map:
+        m_Texture: {fileID: 2800000, guid: b29d9fe74bc0f7d43a738f97c32013c3, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _OcclusionMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -120,6 +128,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
+    - _Use_Normal_Map: 1
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/Gate/GateBackground.mat
+++ b/Assets/Materials/Gate/GateBackground.mat
@@ -141,7 +141,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/Gate/GateMaterial.mat
+++ b/Assets/Materials/Gate/GateMaterial.mat
@@ -128,7 +128,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/GrandCanyon/woodTexture 2.mat
+++ b/Assets/Materials/GrandCanyon/woodTexture 2.mat
@@ -143,6 +143,7 @@ Material:
     - _Surface: 0
     - _Texture_Intensity: 1.31
     - _Use_Normal_Map: 1
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/Gunparts/HatMat.mat
+++ b/Assets/Materials/Gunparts/HatMat.mat
@@ -143,6 +143,7 @@ Material:
     - _Surface: 0
     - _Texture_Intensity: 0.77
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/Gunparts/Telescope.mat
+++ b/Assets/Materials/Gunparts/Telescope.mat
@@ -135,13 +135,15 @@ Material:
     - _QueueOffset: 0
     - _ReceiveShadows: 1
     - _SHADOWS_SOFT: 1
-    - _Smoothness: 1
+    - _Smoothness: 0
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
     - _Use_Normal_Map: 1
+    - _Use_Specular: 1
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/Props/BarrelWood.mat
+++ b/Assets/Materials/Props/BarrelWood.mat
@@ -128,7 +128,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/Props/Cactus.mat
+++ b/Assets/Materials/Props/Cactus.mat
@@ -128,7 +128,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/Props/Rock.mat
+++ b/Assets/Materials/Props/Rock.mat
@@ -128,7 +128,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/Terrain/CraterTown Terrain.mat
+++ b/Assets/Materials/Terrain/CraterTown Terrain.mat
@@ -98,6 +98,10 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _Metallic_Texture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _Normal0:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -111,6 +115,10 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _Normal3:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Normal_Map:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -210,8 +218,11 @@ Material:
     - _SrcBlendAlpha: 1
     - _Surface: 0
     - _TERRAIN_INSTANCED_PERPIXEL_NORMAL: 0
+    - _Texture_Intensity: 1
     - _Texture_Scale: 40
     - _UVSec: 0
+    - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/Terrain/rockcartoon.mat
+++ b/Assets/Materials/Terrain/rockcartoon.mat
@@ -128,7 +128,9 @@ Material:
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
+    - _Texture_Intensity: 1
     - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:

--- a/Assets/Materials/Terrain/testMaterialWood 2.mat
+++ b/Assets/Materials/Terrain/testMaterialWood 2.mat
@@ -98,6 +98,10 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _Metallic_Texture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _Normal0:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -111,6 +115,10 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _Normal3:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Normal_Map:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -210,8 +218,11 @@ Material:
     - _SrcBlendAlpha: 1
     - _Surface: 0
     - _TERRAIN_INSTANCED_PERPIXEL_NORMAL: 0
+    - _Texture_Intensity: 1
     - _Texture_Scale: 40
     - _UVSec: 0
+    - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
@@ -225,6 +236,7 @@ Material:
     - _Red: {r: 1, g: 0, b: 0, a: 0}
     - _Sloped_Color: {r: 0.03752875, g: 1, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _Texture_Tiling: {r: 1, g: 1, b: 0, a: 0}
   m_BuildTextureStacks: []
 --- !u!114 &6701647160567206950
 MonoBehaviour:

--- a/Assets/Materials/Terrain/testMaterialWood 3.mat
+++ b/Assets/Materials/Terrain/testMaterialWood 3.mat
@@ -98,6 +98,10 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _Metallic_Texture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _Normal0:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -111,6 +115,10 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _Normal3:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Normal_Map:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -210,8 +218,11 @@ Material:
     - _SrcBlendAlpha: 1
     - _Surface: 0
     - _TERRAIN_INSTANCED_PERPIXEL_NORMAL: 0
+    - _Texture_Intensity: 1
     - _Texture_Scale: 40
     - _UVSec: 0
+    - _Use_Normal_Map: 0
+    - _Use_Specular: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
@@ -225,6 +236,7 @@ Material:
     - _Red: {r: 1, g: 0, b: 0, a: 0}
     - _Sloped_Color: {r: 0.03752875, g: 1, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _Texture_Tiling: {r: 1, g: 1, b: 0, a: 0}
   m_BuildTextureStacks: []
 --- !u!114 &6701647160567206950
 MonoBehaviour:

--- a/Assets/Shaders/ToonShader.shadergraph
+++ b/Assets/Shaders/ToonShader.shadergraph
@@ -26,6 +26,9 @@
         },
         {
             "m_Id": "43783ab579f140ad944cb00c15365d7e"
+        },
+        {
+            "m_Id": "ad925c4beb8b4eb9af578c6fb4843231"
         }
     ],
     "m_Keywords": [
@@ -43,6 +46,18 @@
     "m_CategoryData": [
         {
             "m_Id": "149dd95217654d938e203b9a499e5a21"
+        },
+        {
+            "m_Id": "9d50ac880b10457f8120b66e5581f92e"
+        },
+        {
+            "m_Id": "63134c6e64d04561a5441947fad9804d"
+        },
+        {
+            "m_Id": "c48397d93fb94ff1b2e0a2bae98a49a8"
+        },
+        {
+            "m_Id": "944ffd23c6f34e9da980aa47e5f926ad"
         }
     ],
     "m_Nodes": [
@@ -189,6 +204,12 @@
         },
         {
             "m_Id": "7798dfff61fb4bca9b3b37b6219a6a0c"
+        },
+        {
+            "m_Id": "442d762c3ca94e1293621f3601cdc81d"
+        },
+        {
+            "m_Id": "25448a353de04ddb844efefbabfb520e"
         }
     ],
     "m_GroupDatas": [
@@ -323,6 +344,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "25448a353de04ddb844efefbabfb520e"
+                },
+                "m_SlotId": 3
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "5b6f9350f68f4d47b8f5a709917afd19"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "29bed0d825be46bd97045240cdc8fdc0"
                 },
                 "m_SlotId": 1
@@ -402,6 +437,20 @@
                     "m_Id": "abbae4592b3141cfae6cfa7df4583de8"
                 },
                 "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "442d762c3ca94e1293621f3601cdc81d"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "25448a353de04ddb844efefbabfb520e"
+                },
+                "m_SlotId": 0
             }
         },
         {
@@ -749,7 +798,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "5b6f9350f68f4d47b8f5a709917afd19"
+                    "m_Id": "25448a353de04ddb844efefbabfb520e"
                 },
                 "m_SlotId": 1
             }
@@ -1353,6 +1402,20 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
+    "m_ObjectId": "0cf33d4b0c3747a49e94f1eb66e5c223",
+    "m_Id": 0,
+    "m_DisplayName": "Predicate",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Predicate",
+    "m_StageCapability": 3,
+    "m_Value": false,
+    "m_DefaultValue": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
     "m_ObjectId": "0f3645017e164fccae35c0b08d3dc9aa",
     "m_Id": 0,
@@ -1503,41 +1566,7 @@
     "m_Type": "UnityEditor.ShaderGraph.CategoryData",
     "m_ObjectId": "149dd95217654d938e203b9a499e5a21",
     "m_Name": "",
-    "m_ChildObjectList": [
-        {
-            "m_Id": "89dac826444a4c2e8496a81957710cb3"
-        },
-        {
-            "m_Id": "46e5bfa302ae413c92640d4fc2a48881"
-        },
-        {
-            "m_Id": "43783ab579f140ad944cb00c15365d7e"
-        },
-        {
-            "m_Id": "b6ec4dfc4f154a02a3d6edc4b7a1e6d5"
-        },
-        {
-            "m_Id": "cfac98a39ec8492ab9f743f65bc52b49"
-        },
-        {
-            "m_Id": "1b6e8e56b63e4f8b8e501b62e70efbf9"
-        },
-        {
-            "m_Id": "9365cf3a61af4dcf9a5e5e8317bc705b"
-        },
-        {
-            "m_Id": "5065323710694a37b10997941719c53d"
-        },
-        {
-            "m_Id": "aed53abfd9734f1c93531108635e16b9"
-        },
-        {
-            "m_Id": "4dc970c83e5e43768e6bf7928a231cf2"
-        },
-        {
-            "m_Id": "de08fc65b9da414299ff295bf09970ec"
-        }
-    ]
+    "m_ChildObjectList": []
 }
 
 {
@@ -1742,6 +1771,52 @@
         "multiplication",
         "times",
         "x"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BranchNode",
+    "m_ObjectId": "25448a353de04ddb844efefbabfb520e",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Branch",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -16.00001335144043,
+            "y": 431.0,
+            "width": 208.00001525878907,
+            "height": 326.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "0cf33d4b0c3747a49e94f1eb66e5c223"
+        },
+        {
+            "m_Id": "e2b94e84d6c048dca1ceeeb833e4abc9"
+        },
+        {
+            "m_Id": "8862cf1a4036438a9d5f91bafc0d787b"
+        },
+        {
+            "m_Id": "7d36df2a69284400bca4a92ce2517598"
+        }
+    ],
+    "synonyms": [
+        "switch",
+        "if",
+        "else"
     ],
     "m_Precision": 0,
     "m_PreviewExpanded": true,
@@ -2521,6 +2596,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "442d762c3ca94e1293621f3601cdc81d",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -189.99996948242188,
+            "y": 468.0,
+            "width": 147.00001525878907,
+            "height": 34.000030517578128
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "cdcb001b90394541b53735413a65c893"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "ad925c4beb8b4eb9af578c6fb4843231"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
     "m_ObjectId": "4484a72cea2e4eb5a7a29d9bee151e13",
     "m_Group": {
@@ -3253,6 +3364,24 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "63134c6e64d04561a5441947fad9804d",
+    "m_Name": "Shadows",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "cfac98a39ec8492ab9f743f65bc52b49"
+        },
+        {
+            "m_Id": "1b6e8e56b63e4f8b8e501b62e70efbf9"
+        },
+        {
+            "m_Id": "9365cf3a61af4dcf9a5e5e8317bc705b"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
     "m_ObjectId": "631e8bfd0b2b488f82d7e7fede919617",
     "m_Group": {
@@ -3868,6 +3997,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "7d36df2a69284400bca4a92ce2517598",
+    "m_Id": 3,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
     "m_ObjectId": "7d7fb85576f1488a9ef6ce0985afdd6e",
     "m_Id": 3,
@@ -4215,6 +4368,30 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "8862cf1a4036438a9d5f91bafc0d787b",
+    "m_Id": 2,
+    "m_DisplayName": "False",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "False",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "88eb852dd0d74415b6efa8b660ae27dc",
     "m_Id": 1,
     "m_DisplayName": "B",
@@ -4557,6 +4734,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "944ffd23c6f34e9da980aa47e5f926ad",
+    "m_Name": "Normals",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "4dc970c83e5e43768e6bf7928a231cf2"
+        },
+        {
+            "m_Id": "de08fc65b9da414299ff295bf09970ec"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
     "m_ObjectId": "956e5b072e774e608108b8d7e996ea75",
     "m_Id": 0,
@@ -4644,6 +4836,27 @@
     "m_Value": 0.699999988079071,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "9d50ac880b10457f8120b66e5581f92e",
+    "m_Name": "Texture",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "89dac826444a4c2e8496a81957710cb3"
+        },
+        {
+            "m_Id": "46e5bfa302ae413c92640d4fc2a48881"
+        },
+        {
+            "m_Id": "43783ab579f140ad944cb00c15365d7e"
+        },
+        {
+            "m_Id": "b6ec4dfc4f154a02a3d6edc4b7a1e6d5"
+        }
+    ]
 }
 
 {
@@ -4980,6 +5193,29 @@
         "e32": 0.0,
         "e33": 1.0
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.BooleanShaderProperty",
+    "m_ObjectId": "ad925c4beb8b4eb9af578c6fb4843231",
+    "m_Guid": {
+        "m_GuidSerialized": "1206d6d6-e366-4251-b804-96b20920d44d"
+    },
+    "m_Name": "Use Specular",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Use Specular",
+    "m_DefaultReferenceName": "_Use_Specular",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": true
 }
 
 {
@@ -5914,6 +6150,24 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "c48397d93fb94ff1b2e0a2bae98a49a8",
+    "m_Name": "Specular",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "ad925c4beb8b4eb9af578c6fb4843231"
+        },
+        {
+            "m_Id": "5065323710694a37b10997941719c53d"
+        },
+        {
+            "m_Id": "aed53abfd9734f1c93531108635e16b9"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "c52c949eaa864cb597c1a4dac8320934",
     "m_Id": 2,
@@ -6102,6 +6356,20 @@
         "e32": 0.0,
         "e33": 1.0
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
+    "m_ObjectId": "cdcb001b90394541b53735413a65c893",
+    "m_Id": 0,
+    "m_DisplayName": "Use Specular",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": false,
+    "m_DefaultValue": false
 }
 
 {
@@ -6466,6 +6734,30 @@
     "m_Position": {
         "x": -174.00009155273438,
         "y": -675.9999389648438
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "e2b94e84d6c048dca1ceeeb833e4abc9",
+    "m_Id": 1,
+    "m_DisplayName": "True",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "True",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     }
 }
 


### PR DESCRIPTION
actually part of this:
- [x] add bool for specular or not on toon shader
- [x] toggle/untoggle on all the materials
- [x] categorize toon shader parameters

tangentially related:
- [ ] make toon shader subgraph so it can be used in e.g. demo material
- [ ] fix metal map issue???


could fix the metallic map issue as well but I'm putting that off for now smh (could be solved with a step function multiplier for the specular that filters out specular at threshold .01 from metal map or sth)