### PR TITLE
Dampen speed lines faster for large speeds

### DIFF
--- a/Assets/Scripts/UI/PlayerHUDController.cs
+++ b/Assets/Scripts/UI/PlayerHUDController.cs
@@ -104,7 +104,8 @@ public class PlayerHUDController : MonoBehaviour
                 return;
             }
 
-            var dampenedMagnitude = Mathf.Lerp(oldLargeVelocity, 1f, Time.fixedDeltaTime);
+            // Dampen larger speeds faster w/log factor
+            var dampenedMagnitude = Mathf.Lerp(oldLargeVelocity, 1f, Time.fixedDeltaTime * Mathf.Log(oldLargeVelocity) * .5f);
             speedLinesMaterial.SetFloat("_LineRemovalRadius", speedLineEase.Evaluate(1 / dampenedMagnitude) * lineRemovalMultiplier);
             speedLinesMaterial.SetVector("_Center", new Vector4(0.5f, 0.5f));
             oldLargeVelocity = dampenedMagnitude;


### PR DESCRIPTION
Previous version had speed lines from huge velocities dampen over several seconds, which felt too long

Closes #(oh we don't have an issue for it lol)