### PR TITLE
Fix leantween canceling wrong ids, fix #422, fix first person arm culling on zoom and certain viewing angles

### DIFF
--- a/Assets/Prefabs/Characters/PlayerArmLeft.prefab
+++ b/Assets/Prefabs/Characters/PlayerArmLeft.prefab
@@ -956,7 +956,7 @@ SkinnedMeshRenderer:
   m_RootBone: {fileID: 7971391927095658884}
   m_AABB:
     m_Center: {x: -0.010198317, y: -0.0017878572, z: 0.04950676}
-    m_Extent: {x: 0.0062388154, y: 0.009813513, z: 0.0126058515}
+    m_Extent: {x: 0.01333882, y: 0.01581351, z: 0.02560585}
   m_DirtyAABB: 0
 --- !u!1 &8321719110810010550
 GameObject:

--- a/Assets/Prefabs/Characters/PlayerArmRight.prefab
+++ b/Assets/Prefabs/Characters/PlayerArmRight.prefab
@@ -95,7 +95,7 @@ Transform:
   - {fileID: 5880885916632462744}
   - {fileID: 3535131488769462984}
   m_Father: {fileID: 0}
-  m_RootOrder: -1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7601771935898208010
 MonoBehaviour:
@@ -631,8 +631,8 @@ SkinnedMeshRenderer:
   m_BlendShapeWeights: []
   m_RootBone: {fileID: 7158862323430776054}
   m_AABB:
-    m_Center: {x: -0.010195851, y: 0.012608443, z: -0.0026928633}
-    m_Extent: {x: 0.006238593, y: 0.010776787, z: 0.0099769235}
+    m_Center: {x: -0.010195851, y: 0.01960844, z: -0.0026928633}
+    m_Extent: {x: 0.01538593, y: 0.01577679, z: 0.019976923}
   m_DirtyAABB: 0
 --- !u!1 &4721697430436054245
 GameObject:

--- a/Assets/Prefabs/Gamestate/StaticInfo.prefab
+++ b/Assets/Prefabs/Gamestate/StaticInfo.prefab
@@ -67,4 +67,6 @@ MonoBehaviour:
   extensionAuction: {fileID: 11400000, guid: ad4a13bed7ceda243beb3334b23d48b0, type: 2}
   startingBody: {fileID: 11400000, guid: bf9666eedd80829a0a6b59278813ba72, type: 2}
   startingBarrel: {fileID: 11400000, guid: 89eab92daa1634e84ace980d00e1880e, type: 2}
+  startingExtension: {fileID: 0}
   secretNames: {fileID: 11400000, guid: 2f3309b3d89e8224e9bac1c33fd04eed, type: 2}
+  cameraFov: 90

--- a/Assets/Scripts/Augment/AugmentImplementations/DDRBody.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/DDRBody.cs
@@ -50,10 +50,10 @@ public class DDRBody : GunBody
     [SerializeField]
     private Precision[] precisionsGoodToBad;
 
-    int arrowMover;
-    int screenFlasher;
-    int screenPulseAnimator;
-    int textAnimator;
+    int arrowMoverTween;
+    int screenFlasherTween;
+    int screenPulseAnimatorTween;
+    int textAnimatorTween;
 
     private float secondsPerUnitHeight;
     private float musicPace;
@@ -85,12 +85,12 @@ public class DDRBody : GunBody
                 ? MusicTrackManager.Singleton.TrackOffset
                 : secondsPerArrow - (MusicTrackManager.Singleton.TimeSinceTrackStart % secondsPerArrow);
 
-            arrowMover = LeanTween.value(gameObject, SetArrowHeigth, startHeight, screenHeight, secondsPerUnitHeight * (screenHeight - startHeight))
+            arrowMoverTween = LeanTween.value(gameObject, SetArrowHeigth, startHeight, screenHeight, secondsPerUnitHeight * (screenHeight - startHeight))
                 .setDelay(delay)
                 .setRepeat(-1)
                 .setOnComplete(ResetArrow).id;
 
-            screenPulseAnimator = LeanTween.value(gameObject, SetBackgroundZoom, 0.5f, 1.5f, musicPace)
+            screenPulseAnimatorTween = LeanTween.value(gameObject, SetBackgroundZoom, 0.5f, 1.5f, musicPace)
                 .setDelay(delay)
                 .setLoopPingPong()
                 .setOnComplete(
@@ -121,18 +121,18 @@ public class DDRBody : GunBody
 
         if (!precision.HasValue)
             return;
-        if (LeanTween.isTweening(textAnimator))
-            LeanTween.cancel(textAnimator);
+        if (LeanTween.isTweening(textAnimatorTween))
+            LeanTween.cancel(textAnimatorTween);
         precisionText.enabled = true;
         precisionText.text = precision.Value.text;
         precisionText.color = precision.Value.color;
-        textAnimator = LeanTween.scale(precisionText.gameObject, new Vector3(1.1f, 1.1f, 1.1f), 0.5f)
+        textAnimatorTween = LeanTween.scale(precisionText.gameObject, new Vector3(1.1f, 1.1f, 1.1f), 0.5f)
             .setEasePunch()
             .setOnComplete(
             () => precisionText.enabled = false).id;
-        if (LeanTween.isTweening(screenFlasher))
-            LeanTween.cancel(screenFlasher);
-        screenFlasher = LeanTween.value(gameObject, SetFlashFactor, 0, 50f, 0.5f).setEasePunch().id;
+        if (LeanTween.isTweening(screenFlasherTween))
+            LeanTween.cancel(screenFlasherTween);
+        screenFlasherTween = LeanTween.value(gameObject, SetFlashFactor, 0, 50f, 0.5f).setEasePunch().id;
 
         gunController.Reload(reloadEfficiencyPercentage * precision.Value.awardFactor);
         animator.OnReload(gunController.stats);
@@ -174,10 +174,10 @@ public class DDRBody : GunBody
 
     private void ResetAndStartArrowTween()
     {
-        if (LeanTween.isTweening(arrowMover))
-            LeanTween.cancel(arrowMover);
+        if (LeanTween.isTweening(arrowMoverTween))
+            LeanTween.cancel(arrowMoverTween);
         ResetArrow();
-        arrowMover = LeanTween.value(gameObject, SetArrowHeigth, arrowHeight, screenHeight, secondsPerUnitHeight * (screenHeight - arrowHeight))
+        arrowMoverTween = LeanTween.value(gameObject, SetArrowHeigth, arrowHeight, screenHeight, secondsPerUnitHeight * (screenHeight - arrowHeight))
             .setRepeat(-1)
             .setOnComplete(ResetArrow).id;
     }

--- a/Assets/Scripts/Augment/GunController.cs
+++ b/Assets/Scripts/Augment/GunController.cs
@@ -58,7 +58,8 @@ public class GunController : MonoBehaviour
 
     private bool isFiring = false;
 
-    private LTDescr recoilTween;
+    private int recoilTween;
+    private int zoomTween;
 
     private void Start()
     {
@@ -164,14 +165,14 @@ public class GunController : MonoBehaviour
 
     public void PlayRecoil(GunStats stats)
     {
-        if (recoilTween != null)
+        if (LeanTween.isTweening(recoilTween))
         {
-            LeanTween.cancel(recoilTween.id);
+            LeanTween.cancel(recoilTween);
             transform.localPosition = new Vector3(transform.localPosition.x, transform.localPosition.y, localGunZOffset);
         }
         var moveAmount = Player != null ? 0.3f : 0.6f;
         // TODO reduce tween time based on fire rate
-        recoilTween = gameObject.LeanMoveLocalZ(moveAmount, 0.2f).setEasePunch();
+        recoilTween = gameObject.LeanMoveLocalZ(moveAmount, 0.2f).setEasePunch().id;
     }
 
     private void ShotFired()

--- a/Assets/Scripts/Control&Input/PlayerMovement.cs
+++ b/Assets/Scripts/Control&Input/PlayerMovement.cs
@@ -117,6 +117,11 @@ public class PlayerMovement : MonoBehaviour
     public delegate void MovementEventBody(Rigidbody body);
     public MovementEventBody onMove;
 
+    private int gunCrouchPerformedTween;
+    private int cameraCrouchPerformedTween;
+    private int gunCrouchCanceledTween;
+    private int cameraCrouchCanceledTween;
+
     void Start()
     {
         body = GetComponent<Rigidbody>();
@@ -142,7 +147,7 @@ public class PlayerMovement : MonoBehaviour
         localGunHolderX = gunHolder.transform.localPosition.x;
         localGunHolderHeight = gunHolder.transform.localPosition.y;
         playerCamera = inputManager.GetComponent<Camera>();
-        startingFov = playerCamera.fieldOfView;
+        startingFov = StaticInfo.Singleton.CameraFov;
 
         if (MatchController.Singleton)
             MatchController.Singleton.onRoundEnd += ResetZoom;
@@ -199,9 +204,17 @@ public class PlayerMovement : MonoBehaviour
 
     private void OnCrouch(InputAction.CallbackContext ctx)
     {
-        if (LeanTween.isTweening(inputManager.gameObject))
+        if (LeanTween.isTweening(cameraCrouchCanceledTween))
         {
-            LeanTween.cancel(inputManager.gameObject);
+            LeanTween.cancel(cameraCrouchCanceledTween);
+            LeanTween.cancel(gunCrouchCanceledTween);
+            inputManager.transform.localPosition = new Vector3(inputManager.transform.localPosition.x, localCameraHeight, inputManager.transform.localPosition.z);
+            gunHolder.transform.localPosition = new Vector3(gunHolder.transform.localPosition.x, localGunHolderHeight, gunHolder.transform.localPosition.z);
+        }
+        if (LeanTween.isTweening(cameraCrouchPerformedTween))
+        {
+            LeanTween.cancel(cameraCrouchPerformedTween);
+            LeanTween.cancel(gunCrouchPerformedTween);
             inputManager.transform.localPosition = new Vector3(inputManager.transform.localPosition.x, localCameraHeight, inputManager.transform.localPosition.z);
             gunHolder.transform.localPosition = new Vector3(gunHolder.transform.localPosition.x, localGunHolderHeight, gunHolder.transform.localPosition.z);
         }
@@ -220,8 +233,8 @@ public class PlayerMovement : MonoBehaviour
         {
             animator.SetBool("Crouching", false);
             strafeForce = strafeForceGrounded;
-            inputManager.gameObject.LeanMoveLocalY(localCameraHeight, 0.2f);
-            gunHolder.LeanMoveLocalY(localGunHolderHeight, 0.2f);
+            cameraCrouchCanceledTween = inputManager.gameObject.LeanMoveLocalY(localCameraHeight, 0.2f).id;
+            gunCrouchCanceledTween = gunHolder.LeanMoveLocalY(localGunHolderHeight, 0.2f).id;
             isDashing = false;
             onLanding -= StartCrouch;
         }
@@ -232,8 +245,8 @@ public class PlayerMovement : MonoBehaviour
     {
         animator.SetBool("Crouching", true);
         strafeForce = strafeForceCrouched;
-        inputManager.gameObject.LeanMoveLocalY(localCameraHeight - crouchedHeightOffset, 0.2f);
-        gunHolder.LeanMoveLocalY(localGunHolderHeight - crouchedHeightGunOffset, 0.2f);
+        cameraCrouchPerformedTween = inputManager.gameObject.LeanMoveLocalY(localCameraHeight - crouchedHeightOffset, 0.2f).id;
+        gunCrouchCanceledTween = gunHolder.LeanMoveLocalY(localGunHolderHeight - crouchedHeightGunOffset, 0.2f).id;
     }
 
     private void EnableDash()

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -359,7 +359,7 @@ public class PlayerManager : MonoBehaviour
 
     private void PlayOnHit()
     {
-        if (Random.Range(0, 1000) > 5)
+        if (Random.Range(0, 10000) > 5)
         {
             hitSounds.Play(audioSource);
         }

--- a/Assets/Scripts/Gamestate/StaticInfo.cs
+++ b/Assets/Scripts/Gamestate/StaticInfo.cs
@@ -55,6 +55,11 @@ public class StaticInfo : MonoBehaviour
     public ReadOnlyArray<Item> Extensions;
     public ReadOnlyArray<OverrideName> SecretNames;
 
+    [Header("Settings")]
+    [SerializeField]
+    private float cameraFov;
+    public float CameraFov => cameraFov;
+
     void Start()
     {
         #region Singleton boilerplate

--- a/Assets/Scripts/UI/PlayerHUDController.cs
+++ b/Assets/Scripts/UI/PlayerHUDController.cs
@@ -30,6 +30,8 @@ public class PlayerHUDController : MonoBehaviour
     private const float ammoSpinDegrees = 30;
     private const float availableDegrees = 270;
 
+    private int ammoTween;
+
 
     [Header("Death")]
 
@@ -73,6 +75,7 @@ public class PlayerHUDController : MonoBehaviour
 
     [SerializeField]
     private RectTransform scopeZoom;
+    private int scopeTween;
 
 
     void Start()
@@ -127,16 +130,16 @@ public class PlayerHUDController : MonoBehaviour
 
     public void UpdateOnFire(float ammoPercent)
     {
-        if (LeanTween.isTweening(ammoHud.gameObject))
+        if (LeanTween.isTweening(ammoTween))
         {
-            LeanTween.cancel(ammoHud.gameObject);
+            LeanTween.cancel(ammoTween);
             ammoBar.gameObject.transform.eulerAngles = new Vector3(ammoBar.gameObject.transform.eulerAngles.x, ammoBar.gameObject.transform.eulerAngles.y, 0);
         }
 
         ammoCapacityMaterial.SetFloat("_Arc2", (1 - ammoPercent) * availableDegrees);
-        ammoHud.gameObject.LeanRotateAroundLocal(Vector3.forward, ammoSpinDegrees, 0.5f).setEaseSpring()
+        ammoTween = ammoHud.gameObject.LeanRotateAroundLocal(Vector3.forward, ammoSpinDegrees, 0.5f).setEaseSpring()
             .setOnStart(
-            () => ammoBar.gameObject.transform.Rotate(new Vector3(0, 0, -ammoSpinDegrees)));
+            () => ammoBar.gameObject.transform.Rotate(new Vector3(0, 0, -ammoSpinDegrees))).id;
     }
 
     public void UpdateOnReload(float ammoPercent)
@@ -160,7 +163,9 @@ public class PlayerHUDController : MonoBehaviour
 
     public void TweenScope(float alpha, float seconds)
     {
-        scopeZoom.LeanAlpha(alpha, seconds).setEaseInOutCubic();
+        if (LeanTween.isTweening(scopeTween))
+            LeanTween.cancel(scopeTween);
+        scopeTween = scopeZoom.LeanAlpha(alpha, seconds).setEaseInOutCubic().id;
     }
 
     public void UpdateDamageBorder(float intensity)


### PR DESCRIPTION
After digging around for a fix for #421, I found this piece of info:
![image](https://github.com/hackerspace-ntnu/Red-Planet-Rampage/assets/54811121/e183fcf9-5e32-4c9d-be17-c93f753ccb9f)
Which seems to be the cause of many tweening headaches (like ammoHUD not always updating correctly on high firerates), which should be resolved in this PR. I also did some small bug squashing for polish

- #421 
- #422 
- Fix first person gun arms sometimes culling on zoom and certain viewing angles