### PR TITLE
Reduce death knockback on huge damage

### DIFF
--- a/Assets/Prefabs/GunParts/Bullets/CannonExplosion.prefab
+++ b/Assets/Prefabs/GunParts/Bullets/CannonExplosion.prefab
@@ -90,8 +90,8 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   radius: 6
-  knockbackForce: 4000
-  knockbackLiftFactor: 0.5
+  knockbackForce: 3000
+  knockbackLiftFactor: 0
   hitBoxLayers:
     serializedVersion: 2
     m_Bits: 8

--- a/Assets/Prefabs/GunParts/RubberSniperExtension.prefab
+++ b/Assets/Prefabs/GunParts/RubberSniperExtension.prefab
@@ -80,8 +80,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   statModifiers:
   - name: ProjectileDamage
-    addition: 10
-    multiplier: 20
+    addition: 0
+    multiplier: 5
     exponential: 1
   outputs:
   - {fileID: 1667389607360852011}

--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -199,7 +199,7 @@ MonoBehaviour:
   hudController: {fileID: 555885729091202788}
   meshBase: {fileID: 5330336945653279977}
   playerIK: {fileID: 142658303258642700}
-  deathKnockbackForceMultiplier: 10
+  deathKnockbackForceMultiplier: 150
   hitSounds: {fileID: 11400000, guid: 90b0dc5583765d64f81545c255b0fa3a, type: 2}
   extraHitSounds: {fileID: 11400000, guid: c5daa2802fa89a54986d53f2fc13cb8f, type: 2}
 --- !u!114 &6717855691676836013

--- a/Assets/Prefabs/Interactables/ExplodingBarrel.prefab
+++ b/Assets/Prefabs/Interactables/ExplodingBarrel.prefab
@@ -242,7 +242,7 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   radius: 6
-  knockbackForce: 3000
+  knockbackForce: 2500
   knockbackLiftFactor: 0.3
   hitBoxLayers:
     serializedVersion: 2

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -155,7 +155,7 @@ public class PlayerManager : MonoBehaviour
 
         ragdollController.ReparentCamera(inputManager.transform);
 
-        var force = info.force.normalized * info.damage * deathKnockbackForceMultiplier;
+        var force = info.force.normalized * Mathf.Log(info.damage) * deathKnockbackForceMultiplier;
         ragdollController.EnableRagdoll(force);
     }
 


### PR DESCRIPTION
- Base death knockback on log(damage) instead of raw damage, to avoid ridiculous speeds (:warning: may need to be adjusted; requires feedback)
- Reduce explosion knockback (cannon still lifts more than barrel)
- Reduce rubber sniper damage to minimum 100 instead of minimum 620