### PR TITLE
Fix HUD being visible from third person

### DIFF
--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -345,6 +345,7 @@ public class PlayerManager : MonoBehaviour
         // Set correct layer on self, mesh and gun (TODO)
         gameObject.layer = playerLayer;
         SetLayerOnSubtree(meshBase, playerLayer);
+        SetLayerOnSubtree(hudController.gameObject, LayerMask.NameToLayer("Gun " + playerIndex));
     }
 
     public virtual void SetGun(Transform offset)


### PR DESCRIPTION
Used to be viewable like this due to incorrect layer:
![image](https://github.com/hackerspace-ntnu/Red-Planet-Rampage/assets/54811121/ec5bc306-55e3-4190-9037-240953f3004f)
