### PR TITLE
Fix gun stopping when AI is hit with hacking extension

### DIFF
--- a/Assets/Scripts/Augment/BulletModifiers/HackingModifier.cs
+++ b/Assets/Scripts/Augment/BulletModifiers/HackingModifier.cs
@@ -31,6 +31,9 @@ public class HackingModifier : MonoBehaviour, ProjectileModifier
             return;
         if (!hitboxController.health.TryGetComponent<PlayerManager>(out var playerManager))
             return;
+        // TODO: Actually disorient the AIs
+        if (playerManager.identity.IsAI)
+            return;
         playerManager.HUDController.PopupSpammer.Spam(Mathf.FloorToInt(state.damage / damageToSpamAmount));
     }
 }


### PR DESCRIPTION
Found and fixed a bug where guns would stop working if an AI got shot with the hacking extension (since thay don't have a HUD)