### PR TITLE
Add lower clouds to skybox, add thicker middle sky gradient

### DIFF
--- a/Assets/Shaders/StylizedSkybox.shadergraph
+++ b/Assets/Shaders/StylizedSkybox.shadergraph
@@ -402,20 +402,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "0e964aadd2fc4ce1950a166f15db42fe"
-                },
-                "m_SlotId": 2
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "9bf4f23cf8bc489ca0e6d99289fcce81"
-                },
-                "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "133665edc90448fc846806e2d9b90027"
                 },
                 "m_SlotId": 2
@@ -985,6 +971,20 @@
                     "m_Id": "0e964aadd2fc4ce1950a166f15db42fe"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "695b709811ab49cbab843698b239b788"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "9bf4f23cf8bc489ca0e6d99289fcce81"
+                },
+                "m_SlotId": 1
             }
         },
         {
@@ -4721,10 +4721,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -4475.2001953125,
+            "x": -4524.0,
             "y": 2882.39990234375,
             "width": 208.0,
-            "height": 325.599853515625
+            "height": 325.60009765625
         }
     },
     "m_Slots": [
@@ -6639,7 +6639,7 @@
     "m_StageCapability": 3,
     "m_Value": {
         "x": 0.3700000047683716,
-        "y": 2.7699999809265138
+        "y": 2.0
     },
     "m_DefaultValue": {
         "x": 0.0,
@@ -8791,7 +8791,7 @@
     "m_ShaderOutputName": "Edge",
     "m_StageCapability": 3,
     "m_Value": {
-        "x": 0.8500000238418579,
+        "x": 0.5,
         "y": 1.0,
         "z": 1.0,
         "w": 1.0
@@ -9660,7 +9660,7 @@
     "m_ShaderOutputName": "B",
     "m_StageCapability": 3,
     "m_Value": {
-        "x": 0.04800000041723251,
+        "x": 0.09799999743700028,
         "y": 0.0,
         "z": 0.0,
         "w": 0.0
@@ -11586,7 +11586,7 @@
     "m_Hidden": false,
     "m_ShaderOutputName": "Scale",
     "m_StageCapability": 3,
-    "m_Value": 10.0,
+    "m_Value": 11.0,
     "m_DefaultValue": 10.0,
     "m_Labels": []
 }
@@ -11821,10 +11821,10 @@
     "m_Theme": 1,
     "m_Position": {
         "serializedVersion": "2",
-        "x": -5268.7998046875,
+        "x": -5268.0,
         "y": 563.2000122070313,
         "width": 3186.39990234375,
-        "height": 1630.4000244140625
+        "height": 1630.400146484375
     },
     "m_Group": {
         "m_Id": ""


### PR DESCRIPTION
Based on feedback, should look better for the arena circleing camera
![image](https://github.com/hackerspace-ntnu/Red-Planet-Rampage/assets/54811121/9d254d6f-60b8-4234-bef9-58c8bce67475)
