### PR TITLE
Fix gamebreaking bidding AI bug

### DIFF
--- a/Assets/Scripts/Auction/BiddingAI.cs
+++ b/Assets/Scripts/Auction/BiddingAI.cs
@@ -88,7 +88,7 @@ public class BiddingAI : BiddingPlayer
 
     private void OnBiddingPlatformChange(BiddingPlatform platform)
     {
-        if (platform != currentDestination)
+        if (!platform || !currentDestination || platform != currentDestination)
             return;
 
         AnimateBid();


### PR DESCRIPTION
Null reference on the currentDestination in the BiddingAI script