### PR TITLE
Add grace time after ready state in item select

### DIFF
--- a/Assets/Scenes/Bidding.unity
+++ b/Assets/Scenes/Bidding.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.22043686, g: 0.062451832, b: 0.039153717, a: 1}
+  m_IndirectSpecularColor: {r: 0.2204368, g: 0.06245181, b: 0.03915371, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2494,6 +2494,10 @@ PrefabInstance:
     - target: {fileID: 5811672364671233866, guid: ace884b1bf546300a85f4176788f481b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490865783486692312, guid: ace884b1bf546300a85f4176788f481b, type: 3}
+      propertyPath: graceTime
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7844404747135833139, guid: ace884b1bf546300a85f4176788f481b, type: 3}
       propertyPath: aiIdentity

--- a/Assets/Scripts/Control&Input/ItemSelectManager.cs
+++ b/Assets/Scripts/Control&Input/ItemSelectManager.cs
@@ -1,10 +1,15 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
 public class ItemSelectManager : MonoBehaviour
 {
+    [SerializeField] private float graceTime = 1;
+
     private List<ItemSelectMenu> itemSelectMenus;
+
+    private Coroutine waitRoutine;
 
     public void StartTrackingMenus()
     {
@@ -13,6 +18,7 @@ public class ItemSelectManager : MonoBehaviour
         {
             itemSelectMenus.Add(menu);
             menu.OnReady += OnReady;
+            menu.OnNotReady += OnNotReady;
         }
     }
 
@@ -22,11 +28,26 @@ public class ItemSelectManager : MonoBehaviour
         AuctionDriver.Singleton.ChangeScene();
     }
 
+    private IEnumerator WaitAndFinish()
+    {
+        yield return new WaitForSeconds(graceTime);
+        Finish();
+    }
+
+    private void OnNotReady(ItemSelectMenu menu)
+    {
+        if (waitRoutine is not null)
+        {
+            StopCoroutine(waitRoutine);
+        }
+    }
+
     private void OnReady(ItemSelectMenu menu)
     {
-        if (itemSelectMenus.All(m => m.IsReady))
+        var allPlayersAreReady = itemSelectMenus.All(m => m.IsReady);
+        if (allPlayersAreReady)
         {
-            Finish();
+            waitRoutine = StartCoroutine(WaitAndFinish());
         }
     }
 }

--- a/Assets/Scripts/Control&Input/ItemSelectMenu.cs
+++ b/Assets/Scripts/Control&Input/ItemSelectMenu.cs
@@ -72,6 +72,7 @@ public class ItemSelectMenu : MonoBehaviour
     public delegate void SelectionEvent(ItemSelectMenu menu);
 
     public SelectionEvent OnReady;
+    public SelectionEvent OnNotReady;
 
     private bool isReady = false;
     public bool IsReady => isReady;
@@ -158,28 +159,34 @@ public class ItemSelectMenu : MonoBehaviour
         if (moveInput.y > 1 - errorMarginInput && gamepadMoveReady)
         {
             MoveUpPerformed();
-            gamepadMoveReady = false;
-            StartCoroutine(GamepadMoveDelay());
+            DelayIfGamepad();
         }
         else if (moveInput.y < -1 + errorMarginInput && gamepadMoveReady)
         {
             MoveDownPerformed();
-            gamepadMoveReady = false;
-            StartCoroutine(GamepadMoveDelay());
-
+            DelayIfGamepad();
         }
         else if (moveInput.x < -1 + errorMarginInput && gamepadMoveReady)
         {
             MoveLeftPerformed();
-            gamepadMoveReady = false;
+            DelayIfGamepad();
+
+            gamepadMoveReady = !inputManager.IsMouseAndKeyboard;
             StartCoroutine(GamepadMoveDelay());
         }
         else if (moveInput.x > 1 - errorMarginInput && gamepadMoveReady)
         {
             MoveRightPerformed();
-            gamepadMoveReady = false;
-            StartCoroutine(GamepadMoveDelay());
+            DelayIfGamepad();
         }
+    }
+
+    private void DelayIfGamepad()
+    {
+        if (inputManager.IsMouseAndKeyboard)
+            return;
+        gamepadMoveReady = false;
+        StartCoroutine(GamepadMoveDelay());
     }
 
     private IEnumerator GamepadMoveDelay()
@@ -265,6 +272,7 @@ public class ItemSelectMenu : MonoBehaviour
                 handleModel.LeanCancel(handleTween, true);
             handleTween = handleModel.LeanRotateAroundLocal(Vector3.up, -140f, 0.5f).setEaseOutBounce().setOnComplete(() => handleModel.transform.localRotation = Quaternion.Euler(handleStartRotation)).id;
             readyIndicator.gameObject.SetActive(false);
+            OnNotReady?.Invoke(this);
         }
     }
 


### PR DESCRIPTION
Add one second where players can see their final state (when all players are ready) and press an input to edit their weapon again if they change their mind.

Also improve responsiveness for keyboard players by disabling the gamepad input delay for them.