### PR TITLE
Rename training mode button

### DIFF
--- a/Assets/Prefabs/UI/MenuCanvas.prefab
+++ b/Assets/Prefabs/UI/MenuCanvas.prefab
@@ -3652,9 +3652,11 @@ MonoBehaviour:
   playerSelectManager: {fileID: 0}
   aIButton: {fileID: 5390649776347757468}
   startButton: {fileID: 7502603491603641025}
+  innputManagerPrefab: {fileID: 0}
   mapNames:
   - CraterTown
   - GrandCanyon
+  loadingScreen: {fileID: 0}
 --- !u!1 &8255412031830499850
 GameObject:
   m_ObjectHideFlags: 0
@@ -4840,7 +4842,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3765489543879290160, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
       propertyPath: m_text
-      value: Tutorial
+      value: Training
       objectReference: {fileID: 0}
     - target: {fileID: 3765489543879290160, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
       propertyPath: m_fontSize

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 785370674}
-  m_IndirectSpecularColor: {r: 0.096855156, g: 0.2404882, b: 0.49282077, a: 1}
+  m_IndirectSpecularColor: {r: 0.096755564, g: 0.2403777, b: 0.49269104, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:


### PR DESCRIPTION
Calling it a tutorial is a little extravagant, it may work better to just call it the training arena that it is. We could split these purposes into an actual tutorial and a sandbox eventually, but for now I think this should work.