### PR TITLE
Input tool tip at start of every match

### DIFF
--- a/Assets/Prefabs/UI/LoadingScreen.prefab
+++ b/Assets/Prefabs/UI/LoadingScreen.prefab
@@ -141,7 +141,7 @@ MonoBehaviour:
   - Leaping off cacti can boost you higher.
   - With the cannon barrel, you can perform safer explosion jumps.
   - Shooting a flying soda can will make it explode.
-  - Lazur beams can be devastating if aimed strategically.
+  - The "BFL" laser beams can be devastating if aimed strategically.
   - Flying hats may work better in enclosed areas, where they can bounce wildly around.
   - If you can't outbid your opponents, the chips you don't spend may come in handy
     later.

--- a/Assets/Scripts/LoadingScreen.cs
+++ b/Assets/Scripts/LoadingScreen.cs
@@ -62,6 +62,11 @@ public class LoadingScreen : MonoBehaviour
         }
     }
 
+    public static void ResetCounter()
+    {
+        loadingCounter = 0;
+    }
+
     private void ShowContent()
     {
         tipsText.text = "";

--- a/Assets/Scripts/UI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/MainMenu/MainMenuController.cs
@@ -96,6 +96,8 @@ public class MainMenuController : MonoBehaviour
             introVideo.Stop();
             introVideo.gameObject.SetActive(false);
             introVideoFirstFrame.SetActive(false);
+            // Reset loading screen
+            LoadingScreen.ResetCounter();
         }
         else
         {


### PR DESCRIPTION
- Make input tooltip/auction tutorial appear at start of every match
- Fix a typo in loadingscreen tip (Lazur is named "BFL" in game)