### PR TITLE
Adjust balance of various gun parts

### DIFF
--- a/Assets/Prefabs/GunParts/CoilBarrel.prefab
+++ b/Assets/Prefabs/GunParts/CoilBarrel.prefab
@@ -432,7 +432,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   interval: 0.15
-  radius: 0.1
+  radius: 0.25
 --- !u!114 &7327065496144923300
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/GunParts/LazurBarrel.prefab
+++ b/Assets/Prefabs/GunParts/LazurBarrel.prefab
@@ -559,7 +559,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   statModifiers:
   - name: ProjectileDamage
-    addition: 30
+    addition: 35
     multiplier: 0
     exponential: 1
   - name: ScreenShakeFactor


### PR DESCRIPTION
- Lower the accuracy of the coil barrel (it would reliably hit on all 4 shots before, which is enough to down a player)
- Increase the damage of the lazur barrel to 35, making 3 hits enough for a kill, which should make it more powerful until we properly buff it