### PR TITLE
Make trash uplink deterministic (enough for netcode)

### DIFF
--- a/Assets/Prefabs/GunParts/Bullets/TrashUplink/FallingAnvil.prefab
+++ b/Assets/Prefabs/GunParts/Bullets/TrashUplink/FallingAnvil.prefab
@@ -64,6 +64,10 @@ PrefabInstance:
       propertyPath: soundEffect
       value: 
       objectReference: {fileID: 11400000, guid: e80bdc42be1f2fe689c509e2ebf9e88b, type: 2}
+    - target: {fileID: 1845054590867389166, guid: 8fdb80db4017fa3f8b0112f22f403433, type: 3}
+      propertyPath: spherecastRadius
+      value: 0.88
+      objectReference: {fileID: 0}
     - target: {fileID: 5109705381442619612, guid: 8fdb80db4017fa3f8b0112f22f403433, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 

--- a/Assets/Prefabs/GunParts/Bullets/TrashUplink/FallingBarrel.prefab
+++ b/Assets/Prefabs/GunParts/Bullets/TrashUplink/FallingBarrel.prefab
@@ -159,6 +159,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1845054590867389166, guid: 8fdb80db4017fa3f8b0112f22f403433, type: 3}
+      propertyPath: spherecastRadius
+      value: 0.29
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 9064784891226460240, guid: 8fdb80db4017fa3f8b0112f22f403433, type: 3}

--- a/Assets/Prefabs/GunParts/Bullets/TrashUplink/FallingComputer.prefab
+++ b/Assets/Prefabs/GunParts/Bullets/TrashUplink/FallingComputer.prefab
@@ -207,6 +207,10 @@ PrefabInstance:
       propertyPath: soundEffect
       value: 
       objectReference: {fileID: 11400000, guid: c1c008fc08e74d26d8ed0ee2b44b294b, type: 2}
+    - target: {fileID: 1845054590867389166, guid: 8fdb80db4017fa3f8b0112f22f403433, type: 3}
+      propertyPath: spherecastRadius
+      value: 1.28
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 9064784891226460240, guid: 8fdb80db4017fa3f8b0112f22f403433, type: 3}

--- a/Assets/Prefabs/GunParts/Bullets/TrashUplink/FallingRock.prefab
+++ b/Assets/Prefabs/GunParts/Bullets/TrashUplink/FallingRock.prefab
@@ -47,8 +47,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c95f9fd5b424be44981732d19a1d45ae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  deadlyVelocityThreshold: 50
   audibleVelocityThreshold: 20
+  initialFallVelocity: 50
+  gravity: 9.81
+  spherecastRadius: 1.46
+  spherecastMask:
+    serializedVersion: 2
+    m_Bits: 9
   soundEffect: {fileID: 11400000, guid: 793a2e8c56b13f2e188e5fd0c9a99d09, type: 2}
   impactExplosion: {fileID: 2954352013874095910, guid: 08bcac62798bad66b9c29629194984b7, type: 3}
 --- !u!54 &995852786161839922
@@ -77,7 +82,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 1
   m_Constraints: 0
-  m_CollisionDetection: 1
+  m_CollisionDetection: 0
 --- !u!82 &2990520310954272431
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/GunParts/Bullets/TrashUplink/FallingTrashcan.prefab
+++ b/Assets/Prefabs/GunParts/Bullets/TrashUplink/FallingTrashcan.prefab
@@ -181,6 +181,10 @@ PrefabInstance:
       propertyPath: soundEffect
       value: 
       objectReference: {fileID: 11400000, guid: a94abf38e18f286f2a0c314c7910b105, type: 2}
+    - target: {fileID: 1845054590867389166, guid: 8fdb80db4017fa3f8b0112f22f403433, type: 3}
+      propertyPath: spherecastRadius
+      value: 0.47
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 9064784891226460240, guid: 8fdb80db4017fa3f8b0112f22f403433, type: 3}

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 785370674}
-  m_IndirectSpecularColor: {r: 0.039053008, g: 0.20197706, b: 0.48861247, a: 1}
+  m_IndirectSpecularColor: {r: 0.5671989, g: 0.6087339, b: 0.68005216, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scripts/Augment/AugmentImplementations/SateliteUplink.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/SateliteUplink.cs
@@ -22,6 +22,9 @@ public class SateliteUplink : MonoBehaviour, ProjectileModifier
     private float launchHeight = 100;
 
     [SerializeField]
+    private float launchPointVariance = 1;
+
+    [SerializeField]
     private float cooldown = 10;
 
     [SerializeField]
@@ -147,7 +150,8 @@ public class SateliteUplink : MonoBehaviour, ProjectileModifier
         launchesThisShot += 1;
 
         var offset = Random.Range(30f, 0);
-        var launchPoint = target + (launchHeight + offset) * Vector3.up;
+        var randomAdjustment = Random.Range(launchPointVariance, -launchPointVariance) * Vector3.forward + Random.Range(launchPointVariance, -launchPointVariance) * Vector3.right;
+        var launchPoint = target + (launchHeight + offset) * Vector3.up + randomAdjustment;
 
         var garbageInstance = garbagePool.Get();
         garbageInstance.transform.parent = garbageParent;

--- a/Assets/Scripts/Hazards/FallingHazard.cs
+++ b/Assets/Scripts/Hazards/FallingHazard.cs
@@ -1,11 +1,18 @@
+using System.Linq;
 using UnityEngine;
 
 public class FallingHazard : MonoBehaviour
 {
-    [SerializeField] private float deadlyVelocityThreshold = 100;
     [SerializeField] private float audibleVelocityThreshold = 50;
+    [SerializeField] private float initialFallVelocity = 10;
+
+    [SerializeField] private float spherecastRadius = 2;
+    [SerializeField] private LayerMask spherecastMask;
+
     [SerializeField] private AudioGroup soundEffect;
     [SerializeField] private ExplosionController impactExplosion;
+
+    private const float gravity = 9.81f; // >:)
 
     private PlayerManager player;
     public PlayerManager Player
@@ -17,9 +24,9 @@ public class FallingHazard : MonoBehaviour
     private Rigidbody body;
     private AudioSource audioSource;
 
-    private bool isFirstImpact = true;
-
-    private float lastVelocity = 0f;
+    private bool isFalling = false;
+    private float lastVelocity;
+    private float fallVelocity;
 
     private void Start()
     {
@@ -32,10 +39,8 @@ public class FallingHazard : MonoBehaviour
         if (!body) body = GetComponent<Rigidbody>();
         if (!audioSource) audioSource = GetComponent<AudioSource>();
 
-        // Reset
-        body.velocity = Vector3.zero;
-        body.angularVelocity = Vector3.zero;
-        body.collisionDetectionMode = CollisionDetectionMode.Continuous;
+        // Disable physics
+        body.isKinematic = true;
 
         // Move to launch point
         var rotation = Quaternion.AngleAxis(Random.Range(0f, 360f), Vector3.up);
@@ -44,11 +49,55 @@ public class FallingHazard : MonoBehaviour
         body.position = position;
         body.rotation = rotation;
 
-        // Launch
-        body.AddForce(500f * Vector3.down, ForceMode.Impulse);
-        body.AddForce(50f * Vector3.down, ForceMode.VelocityChange);
+        fallVelocity = initialFallVelocity;
+        isFalling = true;
+    }
 
-        isFirstImpact = true;
+    private void OnGround(Vector3 point)
+    {
+        soundEffect.Play(audioSource);
+
+        var instance = Instantiate(impactExplosion, point, Quaternion.identity);
+        instance.Init();
+        instance.Explode(player);
+
+        // Reset and enable physics
+        body.velocity = Vector3.zero;
+        body.angularVelocity = Vector3.zero;
+        body.isKinematic = false;
+
+        // Stick to the target position
+        transform.position = point;
+        body.position = point;
+
+        // before bouncing off
+        body.AddForce(10f * (Random.rotation * Vector3.up), ForceMode.VelocityChange);
+
+        isFalling = false;
+    }
+
+    private void FixedUpdate()
+    {
+        if (!isFalling)
+            return;
+
+
+        // Accelerate
+        fallVelocity += gravity * Time.fixedDeltaTime;
+        var fallDistance = fallVelocity * Time.fixedDeltaTime;
+
+        // Check for collision in current distance
+        var colliders = Physics.OverlapCapsule(transform.position + Vector3.down, transform.position + (1 + fallDistance) * Vector3.down, spherecastRadius, spherecastMask)
+                               .Where(c => !(c.gameObject.transform.parent && c.gameObject.transform.parent.TryGetComponent<FallingHazard>(out var _)));
+        if (colliders.Count() > 0)
+        {
+            // Touch down at closest point
+            var point = colliders.Select(c => c.ClosestPoint(transform.position)).OrderBy(p => (transform.position - p).sqrMagnitude).First();
+            OnGround(point);
+            return;
+        }
+
+        transform.position += fallDistance * Vector3.down;
     }
 
     private void LateUpdate()
@@ -67,20 +116,11 @@ public class FallingHazard : MonoBehaviour
             return;
 
         soundEffect.Play(audioSource);
+    }
 
-        if (!isFirstImpact)
-            return;
-
-        // Squared magnitude performs better cuz no square root is required :)
-        var isMovingFastEnoughToKill = lastVelocity > deadlyVelocityThreshold;
-        if (!isMovingFastEnoughToKill)
-            return;
-
-        isFirstImpact = false;
-        body.collisionDetectionMode = CollisionDetectionMode.Discrete;
-
-        var instance = Instantiate(impactExplosion, transform.position, Quaternion.identity);
-        instance.Init();
-        instance.Explode(player);
+    private void OnDrawGizmos()
+    {
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, spherecastRadius);
     }
 }


### PR DESCRIPTION
- Avoid relying on unreliable physics for the fall of the space garbage
- Switch back to physics once the trash hits the ground
- Alter launch position horizontally to make the experience recognizably
  chaotic
- Should be possible to emit the point that was hit back to the modifier
  script for future network syncing