### PR TITLE
Add networked player info to hosted lobbies

### DIFF
--- a/Assets/Materials/Gunparts/DDR/WireDdr.mat
+++ b/Assets/Materials/Gunparts/DDR/WireDdr.mat
@@ -24,7 +24,10 @@ Material:
   m_Shader: {fileID: -6465566751694194690, guid: c5f92ba5fc8552c4dacafaa631cd2fb8, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - MAIN_LIGHT_CALCULATE_SHADOWS
+  - _MAIN_LIGHT_SHADOWS_CASCADE
+  - _SHADOWS_SOFT
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -114,6 +117,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - MAIN_LIGHT_CALCULATE_SHADOWS: 1
     - _AlphaClip: 0
     - _AlphaToMask: 0
     - _BendStartOffset: 0
@@ -132,12 +136,15 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _MAIN_LIGHT_SHADOWS_CASCADE: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.005
     - _QueueControl: 1
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SHADOWS_SOFT: 1
+    - _Shadow_Texture: 0
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1

--- a/Assets/Materials/Gunparts/JIggleAntenna.mat
+++ b/Assets/Materials/Gunparts/JIggleAntenna.mat
@@ -24,7 +24,10 @@ Material:
   m_Shader: {fileID: -6465566751694194690, guid: c5f92ba5fc8552c4dacafaa631cd2fb8, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - MAIN_LIGHT_CALCULATE_SHADOWS
+  - _MAIN_LIGHT_SHADOWS_CASCADE
+  - _SHADOWS_SOFT
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -114,6 +117,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - MAIN_LIGHT_CALCULATE_SHADOWS: 1
     - _AlphaClip: 0
     - _AlphaToMask: 0
     - _BendStartOffset: 0
@@ -132,12 +136,15 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _MAIN_LIGHT_SHADOWS_CASCADE: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.005
     - _QueueControl: 1
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SHADOWS_SOFT: 1
+    - _Shadow_Texture: 1
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1

--- a/Assets/Materials/Gunparts/SniperJiggleMaterial.mat
+++ b/Assets/Materials/Gunparts/SniperJiggleMaterial.mat
@@ -24,7 +24,10 @@ Material:
   m_Shader: {fileID: -6465566751694194690, guid: e1f04211b79795c49b24d9a1ef79297e, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - MAIN_LIGHT_CALCULATE_SHADOWS
+  - _MAIN_LIGHT_SHADOWS_CASCADE
+  - _SHADOWS_SOFT
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Assets/Materials/Gunparts/Solar/Wire1.mat
+++ b/Assets/Materials/Gunparts/Solar/Wire1.mat
@@ -24,7 +24,10 @@ Material:
   m_Shader: {fileID: -6465566751694194690, guid: c5f92ba5fc8552c4dacafaa631cd2fb8, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - MAIN_LIGHT_CALCULATE_SHADOWS
+  - _MAIN_LIGHT_SHADOWS_CASCADE
+  - _SHADOWS_SOFT
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -114,6 +117,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - MAIN_LIGHT_CALCULATE_SHADOWS: 1
     - _AlphaClip: 0
     - _AlphaToMask: 0
     - _BendStartOffset: 0
@@ -132,6 +136,7 @@ Material:
     - _GlossMapScale: 1
     - _Glossiness: 1
     - _GlossyReflections: 1
+    - _MAIN_LIGHT_SHADOWS_CASCADE: 1
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -139,6 +144,8 @@ Material:
     - _QueueControl: 1
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SHADOWS_SOFT: 1
+    - _Shadow_Texture: 1
     - _Smoothness: 1
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1

--- a/Assets/Materials/Gunparts/Solar/Wire2.mat
+++ b/Assets/Materials/Gunparts/Solar/Wire2.mat
@@ -11,7 +11,10 @@ Material:
   m_Shader: {fileID: -6465566751694194690, guid: c5f92ba5fc8552c4dacafaa631cd2fb8, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - MAIN_LIGHT_CALCULATE_SHADOWS
+  - _MAIN_LIGHT_SHADOWS_CASCADE
+  - _SHADOWS_SOFT
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -101,6 +104,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - MAIN_LIGHT_CALCULATE_SHADOWS: 1
     - _AlphaClip: 0
     - _AlphaToMask: 0
     - _BendStartOffset: 0
@@ -119,6 +123,7 @@ Material:
     - _GlossMapScale: 1
     - _Glossiness: 0.70183486
     - _GlossyReflections: 1
+    - _MAIN_LIGHT_SHADOWS_CASCADE: 1
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -126,6 +131,8 @@ Material:
     - _QueueControl: 1
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SHADOWS_SOFT: 1
+    - _Shadow_Texture: 1
     - _Smoothness: 0.70183486
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1

--- a/Assets/Materials/Gunparts/Tether/TetherWire1.mat
+++ b/Assets/Materials/Gunparts/Tether/TetherWire1.mat
@@ -11,7 +11,10 @@ Material:
   m_Shader: {fileID: -6465566751694194690, guid: c5f92ba5fc8552c4dacafaa631cd2fb8, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - MAIN_LIGHT_CALCULATE_SHADOWS
+  - _MAIN_LIGHT_SHADOWS_CASCADE
+  - _SHADOWS_SOFT
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -97,6 +100,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - MAIN_LIGHT_CALCULATE_SHADOWS: 1
     - _AlphaClip: 0
     - _AlphaToMask: 0
     - _BendStartOffset: 0
@@ -115,12 +119,15 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _MAIN_LIGHT_SHADOWS_CASCADE: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.005
     - _QueueControl: 1
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SHADOWS_SOFT: 1
+    - _Shadow_Texture: 1
     - _Smoothness: 0.934
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1

--- a/Assets/Prefabs/Gamestate/StaticInfo.prefab
+++ b/Assets/Prefabs/Gamestate/StaticInfo.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 8335508045275328475}
   - component: {fileID: 6426285471098592642}
   - component: {fileID: 5022952277509122877}
+  - component: {fileID: 2447316725937983354}
   m_Layer: 0
   m_Name: StaticInfo
   m_TagString: Untagged
@@ -123,6 +124,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   IsHosting: 0
+  UserName: 
+  PlayerNames: []
   transportProtocol: {fileID: 6426285471098592642}
 --- !u!114 &6426285471098592642
 MonoBehaviour:
@@ -146,15 +149,16 @@ MonoBehaviour:
   offlineScene: Assets/Scenes/Menu.unity
   onlineScene: Assets/Scenes/Menu.unity
   transport: {fileID: 5022952277509122877}
-  networkAddress: localhost
-  maxConnections: 3
+  networkAddress: 
+  maxConnections: 4
   disconnectInactiveConnections: 0
   disconnectInactiveTimeout: 60
   authenticator: {fileID: 0}
-  playerPrefab: {fileID: 0}
+  playerPrefab: {fileID: 3554710591539111231, guid: d58c933aeda04f2448cddbdadf3a34d7, type: 3}
   autoCreatePlayer: 0
   playerSpawnMethod: 0
-  spawnPrefabs: []
+  spawnPrefabs:
+  - {fileID: 2223786909503164693, guid: 37137050a8c861f41b0386c76e5aa372, type: 3}
   exceptionsDisconnect: 1
   snapshotSettings:
     bufferTimeMultiplier: 2
@@ -186,3 +190,15 @@ MonoBehaviour:
   Timeout: 25
   AllowSteamRelay: 1
   UseNextGenSteamNetworking: 1
+--- !u!114 &2447316725937983354
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8579357797008554893}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a305033fb95a67347ae087ba35c9202c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Input/NetworkPlayer Variant.prefab
+++ b/Assets/Prefabs/Input/NetworkPlayer Variant.prefab
@@ -1,0 +1,193 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2170794445371421878
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -437592331247616425, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: identity
+      value: 
+      objectReference: {fileID: 7954090679051958240}
+    - target: {fileID: 71015680234268067, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_Name
+      value: NetworkPlayer Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268069, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -15.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 435425937908780799, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3124495339848130259, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 71015680234268067, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7386333824761180208}
+    - targetCorrespondingSourceObject: {fileID: 71015680234268067, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -6987224546579483665}
+    - targetCorrespondingSourceObject: {fileID: 71015680234268067, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3102452166401960446}
+    - targetCorrespondingSourceObject: {fileID: 71015680234268067, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7954090679051958240}
+  m_SourcePrefab: {fileID: 100100000, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+--- !u!95 &1883308170059415089 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 289053663840324231, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+  m_PrefabInstance: {fileID: 2170794445371421878}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2223786909503164689 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 71015680234268071, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+  m_PrefabInstance: {fileID: 2170794445371421878}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2223786909503164693 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 71015680234268067, guid: 2872a05bf8e94d541a70726bb35085f3, type: 3}
+  m_PrefabInstance: {fileID: 2170794445371421878}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7386333824761180208
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2223786909503164693}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 0
+  _assetId: 3821175277
+  serverOnly: 0
+  visibility: 0
+  hasSpawned: 0
+--- !u!114 &-6987224546579483665
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2223786909503164693}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f6f3bf89aa97405989c802ba270f815, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 1
+  syncMode: 0
+  syncInterval: 0
+  clientAuthority: 1
+  animator: {fileID: 1883308170059415089}
+--- !u!114 &3102452166401960446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2223786909503164693}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ff3ba0becae47b8b9381191598957c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 1
+  syncMode: 0
+  syncInterval: 0
+  target: {fileID: 2223786909503164689}
+  syncPosition: 1
+  syncRotation: 1
+  syncScale: 0
+  onlySyncOnChange: 1
+  compressRotation: 1
+  interpolatePosition: 1
+  interpolateRotation: 1
+  interpolateScale: 1
+  coordinateSpace: 0
+  sendIntervalMultiplier: 1
+  timelineOffset: 0
+  showGizmos: 0
+  showOverlay: 0
+  overlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+  onlySyncOnChangeCorrectionMultiplier: 2
+  rotationSensitivity: 0.01
+  positionPrecision: 0.01
+  scalePrecision: 0.01
+--- !u!114 &7954090679051958240
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2223786909503164693}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7fa6481de280fb5489fa0e0e0d7a7026, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  color: {r: 0, g: 0, b: 0, a: 0}
+  playerName: 
+  isAI: 0
+  body: {fileID: 0}
+  barrel: {fileID: 0}
+  extension: {fileID: 0}
+  bounty: 5

--- a/Assets/Prefabs/Input/NetworkPlayer Variant.prefab.meta
+++ b/Assets/Prefabs/Input/NetworkPlayer Variant.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 37137050a8c861f41b0386c76e5aa372
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Input/PlayerBidding.prefab
+++ b/Assets/Prefabs/Input/PlayerBidding.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 6717855691676836013}
   - component: {fileID: 3252978923923797766}
   - component: {fileID: 7607358150439154286}
+  - component: {fileID: 2046519985899559615}
   m_Layer: 0
   m_Name: PlayerBidding
   m_TagString: Untagged
@@ -55,11 +56,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe68c66043cf4fa30b1b60bfdcd38608, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ignoreMask:
+  groundCheckMask:
     serializedVersion: 2
     m_Bits: 65335
   lookSpeed: 3
   LookSpeedZoom: 0.75
+  mouseZoomSpeedFactor: 0.1
   groundDrag: 2
   airDrag: 1
   maxVelocityBeforeExtraDamping: 20
@@ -79,12 +81,18 @@ MonoBehaviour:
   airThreshold: 0.4
   slopeAngleThreshold: 50
   state: 1
+  jumpState: 0
   animator: {fileID: 289053663840324231}
   ZoomFov: 30
+  CanMove: 1
+  CanLook: 1
   bottomCaster: {fileID: 943828384506437906}
   topCaster: {fileID: 943828384506437906}
   stepHeight: 0.5
   playerRoot: {fileID: 5539336408495370967}
+  steppingIgnoreMask:
+    serializedVersion: 2
+    m_Bits: 0
 --- !u!23 &71015680234268065
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -187,6 +195,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b92c430e6e288cc42a9a091e7fefacaf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
   interactMask:
     serializedVersion: 2
     m_Bits: 0
@@ -200,6 +211,7 @@ MonoBehaviour:
   inputManager: {fileID: 0}
   identity: {fileID: 0}
   hudController: {fileID: 555885729091202788}
+  playerShadow: {fileID: 0}
   aiTarget: {fileID: 8325754837701600379, guid: c133d38b202cbc94dbc1e02d7ee2e7ba, type: 3}
   AiAimSpot: {fileID: 0}
   meshBase: {fileID: 5330336945653279977}
@@ -363,6 +375,23 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!114 &2046519985899559615
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71015680234268067}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 0
+  _assetId: 4265713113
+  serverOnly: 0
+  visibility: 0
+  hasSpawned: 0
 --- !u!1 &650044701630506088
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Input/PlayerInput.prefab
+++ b/Assets/Prefabs/Input/PlayerInput.prefab
@@ -13,7 +13,6 @@ GameObject:
   - component: {fileID: 3554710591539111229}
   - component: {fileID: 8900440296297243362}
   - component: {fileID: 8358913396528462008}
-  - component: {fileID: 8589831862746193968}
   - component: {fileID: 2624657523749747144}
   m_Layer: 0
   m_Name: PlayerInput
@@ -139,23 +138,6 @@ MonoBehaviour:
   rotationSensitivity: 0.01
   positionPrecision: 0.01
   scalePrecision: 0.01
---- !u!114 &8589831862746193968
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3554710591539111231}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7f6f3bf89aa97405989c802ba270f815, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncDirection: 1
-  syncMode: 0
-  syncInterval: 0.1
-  clientAuthority: 1
-  animator: {fileID: 0}
 --- !u!114 &2624657523749747144
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Input/PlayerInput.prefab
+++ b/Assets/Prefabs/Input/PlayerInput.prefab
@@ -12,8 +12,6 @@ GameObject:
   - component: {fileID: 3554710591539111228}
   - component: {fileID: 3554710591539111229}
   - component: {fileID: 8900440296297243362}
-  - component: {fileID: 8358913396528462008}
-  - component: {fileID: 2624657523749747144}
   m_Layer: 0
   m_Name: PlayerInput
   m_TagString: Untagged
@@ -104,57 +102,6 @@ MonoBehaviour:
   barrel: {fileID: 0}
   extension: {fileID: 0}
   bounty: 5
---- !u!114 &8358913396528462008
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3554710591539111231}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8ff3ba0becae47b8b9381191598957c8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncDirection: 1
-  syncMode: 0
-  syncInterval: 0
-  target: {fileID: 3554710591539111230}
-  syncPosition: 1
-  syncRotation: 1
-  syncScale: 0
-  onlySyncOnChange: 1
-  compressRotation: 1
-  interpolatePosition: 1
-  interpolateRotation: 1
-  interpolateScale: 1
-  coordinateSpace: 0
-  sendIntervalMultiplier: 1
-  timelineOffset: 0
-  showGizmos: 0
-  showOverlay: 0
-  overlayColor: {r: 0, g: 0, b: 0, a: 0.5}
-  onlySyncOnChangeCorrectionMultiplier: 2
-  rotationSensitivity: 0.01
-  positionPrecision: 0.01
-  scalePrecision: 0.01
---- !u!114 &2624657523749747144
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3554710591539111231}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  sceneId: 0
-  _assetId: 2241987887
-  serverOnly: 0
-  visibility: 0
-  hasSpawned: 0
 --- !u!1 &4578288573561392664
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Input/PlayerInputNetwork.prefab
+++ b/Assets/Prefabs/Input/PlayerInputNetwork.prefab
@@ -13,7 +13,6 @@ GameObject:
   - component: {fileID: 3554710591539111229}
   - component: {fileID: 8944991250774289266}
   - component: {fileID: 8358913396528462008}
-  - component: {fileID: 8589831862746193968}
   - component: {fileID: 2624657523749747144}
   m_Layer: 0
   m_Name: PlayerInputNetwork
@@ -76,7 +75,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3554710591539111231}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fa2bad6d55a9a3e769430c95d4358054, type: 3}
   m_Name: 
@@ -139,23 +138,6 @@ MonoBehaviour:
   rotationSensitivity: 0.01
   positionPrecision: 0.01
   scalePrecision: 0.01
---- !u!114 &8589831862746193968
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3554710591539111231}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7f6f3bf89aa97405989c802ba270f815, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncDirection: 1
-  syncMode: 0
-  syncInterval: 0.1
-  clientAuthority: 1
-  animator: {fileID: 0}
 --- !u!114 &2624657523749747144
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Input/PlayerInputNetwork.prefab
+++ b/Assets/Prefabs/Input/PlayerInputNetwork.prefab
@@ -45,7 +45,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3554710591539111231}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
   m_Name: 

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 785370674}
-  m_IndirectSpecularColor: {r: 0.039053008, g: 0.20197706, b: 0.48861247, a: 1}
+  m_IndirectSpecularColor: {r: 0.062339414, g: 0.21930732, b: 0.49510947, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scripts/Auction/AuctionDriver.cs
+++ b/Assets/Scripts/Auction/AuctionDriver.cs
@@ -87,7 +87,7 @@ public class AuctionDriver : MonoBehaviour
 
         playerFactory = GetComponent<PlayerFactory>();
         var aiPlayerCount = PlayerInputManagerController.Singleton.MatchHasAI ?
-            Mathf.Max(4 - PlayerInputManagerController.Singleton.playerInputs.Count, 0) : 0;
+            Mathf.Max(4 - PlayerInputManagerController.Singleton.LocalPlayerInputs.Count, 0) : 0;
         playerFactory.InstantiatePlayersBidding(aiPlayerCount);
         playersInAuction = new HashSet<PlayerManager>(FindObjectsOfType<PlayerManager>());
 
@@ -180,7 +180,7 @@ public class AuctionDriver : MonoBehaviour
     public void ChangeScene()
     {
         StartCoroutine(MatchController.Singleton.WaitAndStartNextRound());
-        PlayerInputManagerController.Singleton.playerInputs.ForEach(playerInput => playerInput.RemoveListeners());
+        PlayerInputManagerController.Singleton.LocalPlayerInputs.ForEach(playerInput => playerInput.RemoveListeners());
     }
     private IEnumerator AnimateGunConstruction(PlayerManager playerManager, RectTransform parent)
     {

--- a/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
+++ b/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
@@ -125,6 +125,7 @@ public class Peer2PeerTransport : NetworkManager
         var playerManager = player.GetComponent<PlayerManager>();
         bool isLocalClient = false;
         string playerName = "";
+        //TODO: Use this dictionary to control connection IDs and playerIdentities, instead of all this nonsene string.equals stuff
         if (SteamManager.Singleton.PlayerDictionary.TryGetValue(connection.connectionId, out var playerDetails))
         {
             playerManager.identity.playerName = playerDetails.Item1;
@@ -132,7 +133,7 @@ public class Peer2PeerTransport : NetworkManager
             playerName = playerDetails.Item1;
             playerManager.identity.color = PlayerInputManagerController.Singleton.PlayerColors[playerDetails.Item2];
         }
-        //NetworkServer.AddPlayerForConnection(connection, playerManager.gameObject);
+        NetworkServer.AddPlayerForConnection(connection, playerManager.gameObject);
         player.transform.position = spawn.position;
         player.transform.rotation = spawn.rotation;
         if (isLocalClient)
@@ -167,7 +168,6 @@ public class Peer2PeerTransport : NetworkManager
             // Set unique layer for player
             playerManager.SetLayer(input.playerInput.playerIndex);
             movement.SetInitialRotation(spawn.eulerAngles.y * Mathf.Deg2Rad);
-            NetworkServer.Spawn(player, connection);
         }
         else
         {

--- a/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
+++ b/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
@@ -34,7 +34,7 @@ public class Peer2PeerTransport : NetworkManager
     public override void OnClientConnect()
     {
         base.OnClientConnect();
-        // TODO: A better check than this so we can have multple local players agains online
+        // TODO: A better check than this so we can have multiple local players again online
         if (NetworkServer.connections.Count == 1)
         {
             NetworkClient.Send(new PlayerInfo(PlayerType.Local));
@@ -50,14 +50,18 @@ public class Peer2PeerTransport : NetworkManager
         // TODO: Edit joined players manually here (steamname, colors, numbers etc)
         if (info.type == PlayerType.Local)
         {
-            Debug.Log(PlayerInputManagerController.Singleton.playerInputs[0].gameObject.name);
+            Debug.Log(PlayerInputManagerController.Singleton.LocalPlayerInputs[0].gameObject.name);
             GameObject player = Instantiate(playerPrefab);
+            player.GetComponent<InputManager>().PlayerCamera.enabled = false;
             NetworkServer.AddPlayerForConnection(connection, player);
             //NetworkServer.ReplacePlayerForConnection(connection, PlayerInputManagerController.Singleton.playerInputs[0].gameObject);
         }
         else
         {
             GameObject player = Instantiate(playerPrefab);
+            var playerInput = player.GetComponent<InputManager>();
+            playerInput.PlayerCamera.enabled = false;
+            playerInput.enabled = false;
             NetworkServer.AddPlayerForConnection(connection, player);
         }
             

--- a/Assets/Scripts/Control&Input/PlayerInputManagerController.cs
+++ b/Assets/Scripts/Control&Input/PlayerInputManagerController.cs
@@ -6,12 +6,15 @@ public class PlayerInputManagerController : MonoBehaviour
 {
     public static PlayerInputManagerController Singleton { get; private set; }
 
-    public List<InputManager> playerInputs = new List<InputManager>();
+    public List<InputManager> LocalPlayerInputs = new List<InputManager>();
+    public List<PlayerIdentityNetwork> NetworkClients = new List<PlayerIdentityNetwork>();
+    public int PlayerCount => NetworkClients.Count > 0 ? NetworkClients.Count : LocalPlayerInputs.Count;
 
     public PlayerInputManager PlayerInputManager;
 
     [SerializeField]
     private Color[] playerColors;
+    public Color[] PlayerColors => playerColors;
 
     [SerializeField]
     private string[] playerNames;
@@ -57,16 +60,16 @@ public class PlayerInputManagerController : MonoBehaviour
 
     public void RemoveListeners()
     {
-        playerInputs.ForEach(playerInput => playerInput.RemoveListeners());
+        LocalPlayerInputs.ForEach(playerInput => playerInput.RemoveListeners());
     }
 
     private void OnPlayerJoined(PlayerInput playerInput)
     {
         var playerIdentity = playerInput.GetComponent<PlayerIdentity>();
-        playerIdentity.color = playerColors[playerInputs.Count];
-        playerIdentity.playerName = playerNames[playerInputs.Count];
+        playerIdentity.color = playerColors[LocalPlayerInputs.Count];
+        playerIdentity.playerName = playerNames[LocalPlayerInputs.Count];
         InputManager inputManager = playerInput.GetComponent<InputManager>();
-        playerInputs.Add(inputManager);
+        LocalPlayerInputs.Add(inputManager);
         onPlayerInputJoined(inputManager);
     }
 
@@ -77,7 +80,7 @@ public class PlayerInputManagerController : MonoBehaviour
     /// <param name="mapNameOrId">Name of the inputMap you want to change to</param>
     public void ChangeInputMaps(string mapNameOrId)
     {
-        playerInputs.ForEach(playerInput =>
+        LocalPlayerInputs.ForEach(playerInput =>
         {
             playerInput.playerInput.SwitchCurrentActionMap(mapNameOrId);
             playerInput.RemoveListeners();

--- a/Assets/Scripts/Control&Input/PlayerInputManagerController.cs
+++ b/Assets/Scripts/Control&Input/PlayerInputManagerController.cs
@@ -1,3 +1,4 @@
+using Mirror;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -7,7 +8,7 @@ public class PlayerInputManagerController : MonoBehaviour
     public static PlayerInputManagerController Singleton { get; private set; }
 
     public List<InputManager> LocalPlayerInputs = new List<InputManager>();
-    public List<PlayerIdentityNetwork> NetworkClients = new List<PlayerIdentityNetwork>();
+    public List<NetworkConnectionToClient> NetworkClients = new List<NetworkConnectionToClient>();
     public int PlayerCount => NetworkClients.Count > 0 ? NetworkClients.Count : LocalPlayerInputs.Count;
 
     public PlayerInputManager PlayerInputManager;

--- a/Assets/Scripts/Control&Input/ReturnToMainMenuGate.cs
+++ b/Assets/Scripts/Control&Input/ReturnToMainMenuGate.cs
@@ -18,7 +18,7 @@ public class ReturnToMainMenuGate : MonoBehaviour, Interactable
     private void ReturnToMainMenu()
     {
         PlayerInputManagerController.Singleton.ChangeInputMaps("Menu");
-        PlayerInputManagerController.Singleton.playerInputs.ForEach(input => input.GetComponent<PlayerIdentity>().resetItems());
+        PlayerInputManagerController.Singleton.LocalPlayerInputs.ForEach(input => input.GetComponent<PlayerIdentity>().resetItems());
         if (!SteamManager.Singleton.ChangeScene("Menu"))
             SceneManager.LoadSceneAsync("Menu");
     }

--- a/Assets/Scripts/Gamestate/MatchController.cs
+++ b/Assets/Scripts/Gamestate/MatchController.cs
@@ -124,7 +124,7 @@ public class MatchController : MonoBehaviour
     {
         if (rounds.Count == 0)
         {
-            PlayerInputManagerController.Singleton.playerInputs.ForEach(input => input.GetComponent<PlayerIdentity>().resetItems());
+            PlayerInputManagerController.Singleton.LocalPlayerInputs.ForEach(input => input.GetComponent<PlayerIdentity>().resetItems());
         }
         playerFactory = FindObjectOfType<PlayerFactory>();
 
@@ -133,7 +133,7 @@ public class MatchController : MonoBehaviour
 
         // Makes shooting end quickly if testing with 1 player
 #if UNITY_EDITOR
-        if (PlayerInputManagerController.Singleton.playerInputs.Count == 1)
+        if (PlayerInputManagerController.Singleton.LocalPlayerInputs.Count == 1)
             roundLength = 100f;
 #endif
         GameObject mainLight = GameObject.FindGameObjectsWithTag("MainLight")[0];
@@ -148,7 +148,7 @@ public class MatchController : MonoBehaviour
             collectableChips = FindObjectsOfType<CollectableChip>().ToList();
         // Setup of playerInputs
         var aiPlayerCount = PlayerInputManagerController.Singleton.MatchHasAI ?
-            Mathf.Max(4 - PlayerInputManagerController.Singleton.playerInputs.Count, 0) : 0;
+            Mathf.Max(4 - PlayerInputManagerController.Singleton.LocalPlayerInputs.Count, 0) : 0;
         playerFactory.InstantiatePlayersFPS(aiPlayerCount)
             .ForEach(player => players.Add(new Player(player.identity, player, startAmount)));
 
@@ -320,7 +320,7 @@ public class MatchController : MonoBehaviour
 
         MusicTrackManager.Singleton.SwitchTo(MusicType.Menu);
         rounds = new List<Round>();
-        PlayerInputManagerController.Singleton.playerInputs.ForEach(input => input.GetComponent<PlayerIdentity>().resetItems());
+        PlayerInputManagerController.Singleton.LocalPlayerInputs.ForEach(input => input.GetComponent<PlayerIdentity>().resetItems());
         if (!SteamManager.Singleton.ChangeScene("Menu"))
             SceneManager.LoadSceneAsync("Menu");
     }

--- a/Assets/Scripts/Gamestate/MatchController.cs
+++ b/Assets/Scripts/Gamestate/MatchController.cs
@@ -148,7 +148,7 @@ public class MatchController : MonoBehaviour
             collectableChips = FindObjectsOfType<CollectableChip>().ToList();
         // Setup of playerInputs
         var aiPlayerCount = PlayerInputManagerController.Singleton.MatchHasAI ?
-            Mathf.Max(4 - PlayerInputManagerController.Singleton.LocalPlayerInputs.Count, 0) : 0;
+            Mathf.Max(4 - PlayerInputManagerController.Singleton.PlayerCount, 0) : 0;
         playerFactory.InstantiatePlayersFPS(aiPlayerCount)
             .ForEach(player => players.Add(new Player(player.identity, player, startAmount)));
 

--- a/Assets/Scripts/Gamestate/PlayerFactory.cs
+++ b/Assets/Scripts/Gamestate/PlayerFactory.cs
@@ -111,10 +111,14 @@ public class PlayerFactory : MonoBehaviour
         inputManager.transform.parent = player.transform;
 
         // Tell the network synchronization that the player prefab should be synced
-        inputManager.GetComponent<NetworkTransformReliable>().target = player.transform;
-        var animator = inputManager.GetComponent<NetworkAnimator>();
-        animator.animator = player.GetComponent<PlayerMovement>().Animator;
-        animator.enabled = true;
+        if (inputManager.TryGetComponent<NetworkTransformReliable>(out var networkTransform))
+        { 
+            networkTransform.target = player.transform;
+            var animator = inputManager.GetComponent<NetworkAnimator>();
+            animator.animator = player.GetComponent<PlayerMovement>().Animator;
+            animator.enabled = true;
+        }
+
 
         // Set recieved playerInput (and most importantly its camera) at an offset from player's position
         inputManager.transform.localPosition = cameraOffset.localPosition;

--- a/Assets/Scripts/Gamestate/PlayerFactory.cs
+++ b/Assets/Scripts/Gamestate/PlayerFactory.cs
@@ -54,7 +54,7 @@ public class PlayerFactory : MonoBehaviour
         if (!overrideMatchManager)
             return;
 
-        playerInputManagerController.playerInputs.ForEach(input => input.GetComponent<PlayerIdentity>().resetItems());
+        playerInputManagerController.LocalPlayerInputs.ForEach(input => input.GetComponent<PlayerIdentity>().resetItems());
         InstantiatePlayersFPS();
     }
 
@@ -81,11 +81,11 @@ public class PlayerFactory : MonoBehaviour
         var shuffledSpawnPoints = spawnPoints.ShuffledCopy();
 
         var playerList = new List<PlayerManager>();
-        for (int i = 0; i < playerInputManagerController.playerInputs.Count; i++)
+        for (int i = 0; i < playerInputManagerController.LocalPlayerInputs.Count; i++)
         {
-            playerList.Add(instantiate(playerInputManagerController.playerInputs[i], shuffledSpawnPoints[i % spawnPoints.Length]));
+            playerList.Add(instantiate(playerInputManagerController.LocalPlayerInputs[i], shuffledSpawnPoints[i % spawnPoints.Length]));
         }
-        for (int i = playerInputManagerController.playerInputs.Count; i < playerInputManagerController.playerInputs.Count + aiPlayerCount; i++)
+        for (int i = playerInputManagerController.LocalPlayerInputs.Count; i < playerInputManagerController.LocalPlayerInputs.Count + aiPlayerCount; i++)
         {
             var spawnPoint = shuffledSpawnPoints[i % spawnPoints.Length];
             var aiPlayer = instantiateAI(i, spawnPoint);
@@ -185,7 +185,7 @@ public class PlayerFactory : MonoBehaviour
         var aiOpponent = Instantiate(aIOpponent, spawnPoint.position, spawnPoint.rotation);
         AIManager manager = aiOpponent.GetComponent<AIManager>();
         manager.SetLayer(index);
-        manager.SetIdentity(identity ? identity : existingAiIdentities[index - playerInputManagerController.playerInputs.Count]);
+        manager.SetIdentity(identity ? identity : existingAiIdentities[index - playerInputManagerController.LocalPlayerInputs.Count]);
         manager.GetComponent<AIMovement>().SetInitialRotation(spawnPoint.eulerAngles.y * Mathf.Deg2Rad);
         return manager;
     }
@@ -195,7 +195,7 @@ public class PlayerFactory : MonoBehaviour
         var aiOpponent = Instantiate(aIBidder, spawnPoint.position, spawnPoint.rotation);
         AIManager manager = aiOpponent.GetComponent<AIManager>();
         manager.SetLayer(index);
-        manager.SetIdentity(existingAiIdentities[index - playerInputManagerController.playerInputs.Count]);
+        manager.SetIdentity(existingAiIdentities[index - playerInputManagerController.LocalPlayerInputs.Count]);
         return manager;
     }
 }

--- a/Assets/Scripts/Gamestate/PlayerFactory.cs
+++ b/Assets/Scripts/Gamestate/PlayerFactory.cs
@@ -61,6 +61,8 @@ public class PlayerFactory : MonoBehaviour
     public List<PlayerManager> InstantiatePlayersFPS(int aiPlayerCount = 0)
     {
         playerInputManagerController.ChangeInputMaps("FPS");
+        if (NetworkManager.singleton.isNetworkActive)
+            return new List<PlayerManager>();
         return InstantiateInputsOnSpawnpoints(InstantiateFPSPlayer, InstantiateFPSAI, aiPlayerCount);
     }
 
@@ -95,13 +97,18 @@ public class PlayerFactory : MonoBehaviour
         return playerList;
     }
 
+    public Transform[] GetRandomSpawnpoints()
+    {
+        return spawnPoints.ShuffledCopy();
+    }
+
 
     /// <summary>
     /// Spawns a playerPrefab and attaches a playerInput to it as a child.
     /// This function is where you should add delegate events for them to be properly invoked.
     /// </summary>
     /// <param name="inputManager">PlayerInput to tie the player prefab to.</param>
-    private PlayerManager InstantiateFPSPlayer(InputManager inputManager, Transform spawnPoint)
+    public PlayerManager InstantiateFPSPlayer(InputManager inputManager, Transform spawnPoint)
     {
         // Spawn player at spawnPoint's position with spawnPoint's rotation
         GameObject player = Instantiate(playerPrefab, spawnPoint.position, spawnPoint.rotation);

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -1,3 +1,4 @@
+using Mirror;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.Animations;
@@ -7,7 +8,7 @@ using UnityEngine.Serialization;
 
 [RequireComponent(typeof(PlayerMovement))]
 [RequireComponent(typeof(AudioSource))]
-public class PlayerManager : MonoBehaviour
+public class PlayerManager : NetworkBehaviour
 {
     // Layers 12 through 15 are gun layers.
     protected static int allGunsMask = (1 << 12) | (1 << 13) | (1 << 14) | (1 << 15);
@@ -132,7 +133,8 @@ public class PlayerManager : MonoBehaviour
         aiTargetCollider = Instantiate(aiTarget).GetComponent<AITarget>();
         aiTargetCollider.Owner = this;
         aiTargetCollider.transform.position = transform.position;
-        identity.onChipChange += hudController.OnChipChange;
+        if (identity)
+            identity.onChipChange += hudController.OnChipChange;
     }
 
     private void Update()

--- a/Assets/Scripts/PlayerSelect/PlayerSelectManager.cs
+++ b/Assets/Scripts/PlayerSelect/PlayerSelectManager.cs
@@ -50,6 +50,14 @@ public class PlayerSelectManager : MonoBehaviour
         {
             animatorParameters.Add(playerAnimators[0].GetParameter(i).name);
         }
+        if (SteamManager.IsSteamActive)
+            SteamManager.Singleton.LobbyPlayerUpdate += SetLobby;
+    }
+
+    public void SetLobby()
+    {
+        for (int i = 0; i < SteamManager.Singleton.PlayerNames.Count; i++)
+            SetupPlayerSelectModels(SteamManager.Singleton.PlayerNames[i], playerInputManagerController.PlayerColors[i], i);
     }
 
     /// <summary>
@@ -119,13 +127,13 @@ public class PlayerSelectManager : MonoBehaviour
         yield return new WaitForSeconds(5f);
         while (true)
         {
-            int randomAnimatorNumber = Random.Range(0, playerInputManagerController.playerInputs.Count); // Choose random playermodel to animate
+            int randomAnimatorNumber = Random.Range(0, playerInputManagerController.PlayerCount); // Choose random playermodel to animate
 
             Animator randomAnimator = playerAnimators[randomAnimatorNumber]; // Get the animator for one of the players that has a connected input
 
             // If randomAnimatorNumber is player all the way to the right, don't include cardpeek trigger
             string randomTrigger = "";
-            if (randomAnimatorNumber == playerInputManagerController.playerInputs.Count - 1)
+            if (randomAnimatorNumber == playerInputManagerController.PlayerCount - 1)
             {
                 randomTrigger = randomAnimator.GetParameter(Random.Range(2, randomAnimator.parameterCount)).name; // Choose a random trigger to set, excluding CardPeek
             }
@@ -139,7 +147,7 @@ public class PlayerSelectManager : MonoBehaviour
             }
             
 
-            if ((randomTrigger == "CardPeek" || randomTrigger == "CardPeekReaction") && (playerInputManagerController.playerInputs.Count > 1) && (cardPeekCounter == 0))
+            if ((randomTrigger == "CardPeek" || randomTrigger == "CardPeekReaction") && (playerInputManagerController.PlayerCount > 1) && (cardPeekCounter == 0))
             {
                 randomAnimator.SetTrigger("CardPeek");
                 playerAnimators[randomAnimatorNumber + 1].SetTrigger("CardPeekReaction");
@@ -161,5 +169,10 @@ public class PlayerSelectManager : MonoBehaviour
             yield return new WaitForSeconds(Random.Range(minimumTime, maximumTime));
         }
     }
-    
+
+    private void OnDestroy()
+    {
+        if (SteamManager.IsSteamActive)
+            SteamManager.Singleton.LobbyPlayerUpdate -= SetLobby;
+    }
 }

--- a/Assets/Scripts/UI/GlobalHUDController.cs
+++ b/Assets/Scripts/UI/GlobalHUDController.cs
@@ -20,7 +20,7 @@ public class GlobalHUDController : MonoBehaviour
     void Start()
     {
         // Places the roundTimer at appropriate place on split screen
-        if (PlayerInputManagerController.Singleton.playerInputs.Count > 2)
+        if (PlayerInputManagerController.Singleton.LocalPlayerInputs.Count > 2)
         {
             roundTimer.alignment = TextAlignmentOptions.Center;
         }

--- a/Assets/Scripts/UI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/MainMenu/MainMenuController.cs
@@ -94,7 +94,7 @@ public class MainMenuController : MonoBehaviour
         playerInputManagerController.AddJoinListener();
         playerInputManagerController.PlayerInputManager.splitScreen = false;
         playerInputManagerController.onPlayerInputJoined += AddPlayer;
-        if (playerInputManagerController.playerInputs.Count > 0)
+        if (playerInputManagerController.LocalPlayerInputs.Count > 0)
         {
             // Already played, just show the menu.
             TransferExistingInputs();
@@ -201,7 +201,7 @@ public class MainMenuController : MonoBehaviour
     private void TransferExistingInputs()
     {
         playerInputManagerController.ChangeInputMaps("Menu");
-        foreach (InputManager inputs in playerInputManagerController.playerInputs)
+        foreach (InputManager inputs in playerInputManagerController.LocalPlayerInputs)
         {
             AddPlayer(inputs);
         }
@@ -334,7 +334,10 @@ public class MainMenuController : MonoBehaviour
     // TODO: Make dedicated hosting UI instead.
     public void HostLobby()
     {
+        if (!SteamManager.IsSteamActive)
+            return;
         SteamManager.Singleton.HostLobby();
+        playerSelectManager.SetLobby();
     }
 
     public void LeaveLobby()

--- a/Assets/Scripts/UI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/MainMenu/MainMenuController.cs
@@ -303,7 +303,7 @@ public class MainMenuController : MonoBehaviour
 
     public void StartGameButton(Selectable target)
     {
-        bool canPlay = (playerInputManagerController.MatchHasAI || playerInputs.Count > 1);
+        bool canPlay = (playerInputManagerController.MatchHasAI || PlayerInputManagerController.Singleton.PlayerCount > 1);
         if (canPlay)
         {
             SwitchToMenu(mapSelectMenu);

--- a/Assets/Scripts/Utils/SteamManager.cs
+++ b/Assets/Scripts/Utils/SteamManager.cs
@@ -32,7 +32,7 @@ public class SteamManager : MonoBehaviour
     public bool IsHosting = false;
     public string UserName;
     public List<string> PlayerNames = new List<string>();
-
+    public Dictionary<int, (string, int)> PlayerDictionary = new Dictionary<int, (string, int)>();
     public delegate void LobbyEvent();
     public LobbyEvent LobbyPlayerUpdate;
 

--- a/Assets/Scripts/Utils/SteamManager.cs
+++ b/Assets/Scripts/Utils/SteamManager.cs
@@ -27,8 +27,14 @@ public class SteamManager : MonoBehaviour
     private const int steamAppID = 2717710;
     public static SteamManager Singleton;
     public int ConnectedPlayers => transportProtocol.numPlayers;
-    private bool isSteamInitialized;
+    private static bool isSteamInitialized;
+    public static bool IsSteamActive => isSteamInitialized;
     public bool IsHosting = false;
+    public string UserName;
+    public List<string> PlayerNames = new List<string>();
+
+    public delegate void LobbyEvent();
+    public LobbyEvent LobbyPlayerUpdate;
 
     private bool shouldStoreStats = false;
 
@@ -82,6 +88,7 @@ public class SteamManager : MonoBehaviour
         lobbyUpdate = Callback<LobbyChatUpdate_t>.Create(OnLobbyUpdate);
 
         RequestStats();
+        UserName = SteamFriends.GetPersonaName();
     }
 
     private void RequestStats()
@@ -148,7 +155,17 @@ public class SteamManager : MonoBehaviour
     private void OnLobbyEnter(LobbyEnter_t callback)
     {
         // All users
+        PlayerInputManagerController.Singleton.RemoveJoinListener();
         // TODO: set steam names over players
+        var lobbyId = new CSteamID(callback.m_ulSteamIDLobby);
+        Debug.Log("onLobbyUp");
+        for (int i = 0; i < SteamMatchmaking.GetNumLobbyMembers(lobbyId); i++)
+        {
+            string name = SteamFriends.GetFriendPersonaName(SteamMatchmaking.GetLobbyMemberByIndex(lobbyId, i));
+            if (!PlayerNames.Contains(name))
+                PlayerNames.Add(name);
+        }
+        LobbyPlayerUpdate.Invoke();
         if (NetworkServer.active)
             return;
         // Only clients from here!
@@ -158,13 +175,31 @@ public class SteamManager : MonoBehaviour
 
     private void OnLobbyUpdate(LobbyChatUpdate_t callback)
     {
-        //TODO: handle other players leaving/joining
+        var lobbyId = new CSteamID(callback.m_ulSteamIDLobby);
+        Debug.Log("onLobbyUp");
+        for (int i = 0; i < SteamMatchmaking.GetNumLobbyMembers(lobbyId); i++)
+        {
+            string name = SteamFriends.GetFriendPersonaName(SteamMatchmaking.GetLobbyMemberByIndex(lobbyId, i));
+            if (!PlayerNames.Contains(name))
+                PlayerNames.Add(name);
+        }
+        LobbyPlayerUpdate.Invoke();
     }
 
     public void HostLobby()
     {
-        if (isSteamInitialized)
-            SteamMatchmaking.CreateLobby(ELobbyType.k_ELobbyTypeFriendsOnly, transportProtocol.maxConnections);
+        if (!isSteamInitialized)
+            return;
+
+        SteamMatchmaking.CreateLobby(ELobbyType.k_ELobbyTypeFriendsOnly, transportProtocol.maxConnections);
+        // Disable local joining
+        PlayerInputManagerController.Singleton.RemoveJoinListener();
+        for (int i = 0; i < PlayerInputManagerController.Singleton.LocalPlayerInputs.Count; i++)
+        {
+            if (i == 0)
+                continue;
+            PlayerInputManagerController.Singleton.LocalPlayerInputs[i].gameObject.SetActive(false);
+        } 
     }
 
     public void LeaveLobby()

--- a/Assets/Shaders/BendyJiggleDisplacement.shadergraph
+++ b/Assets/Shaders/BendyJiggleDisplacement.shadergraph
@@ -28,7 +28,17 @@
             "m_Id": "760f0cb168744730a047cecbaaceb336"
         }
     ],
-    "m_Keywords": [],
+    "m_Keywords": [
+        {
+            "m_Id": "1da28ca55a624361b7bf627f762ea626"
+        },
+        {
+            "m_Id": "0b324e03d5fb428fa44d693ebcf653eb"
+        },
+        {
+            "m_Id": "79943f6c050e4cf0a20051379c88eb72"
+        }
+    ],
     "m_Dropdowns": [],
     "m_CategoryData": [
         {
@@ -39,6 +49,9 @@
         },
         {
             "m_Id": "1a5603be227140999e74258896dd7408"
+        },
+        {
+            "m_Id": "6a628d1ead2d436c96e8e8e39f2b2663"
         }
     ],
     "m_Nodes": [
@@ -53,21 +66,6 @@
         },
         {
             "m_Id": "98e85fa53447436fb591e9259582b45c"
-        },
-        {
-            "m_Id": "257408cf1d7c4e338c488c54a05eaa26"
-        },
-        {
-            "m_Id": "b3755e8dec5f4c06bd2100508ac05677"
-        },
-        {
-            "m_Id": "069c396c412f472da7e8284329528db0"
-        },
-        {
-            "m_Id": "6079c2f81db342dc8cb04f9b14e1af19"
-        },
-        {
-            "m_Id": "8cb7793e38124380a44425bd5fc82380"
         },
         {
             "m_Id": "e06e4f5683e349439e4899590b1a1d86"
@@ -461,21 +459,6 @@
         "m_Blocks": [
             {
                 "m_Id": "98e85fa53447436fb591e9259582b45c"
-            },
-            {
-                "m_Id": "257408cf1d7c4e338c488c54a05eaa26"
-            },
-            {
-                "m_Id": "b3755e8dec5f4c06bd2100508ac05677"
-            },
-            {
-                "m_Id": "069c396c412f472da7e8284329528db0"
-            },
-            {
-                "m_Id": "6079c2f81db342dc8cb04f9b14e1af19"
-            },
-            {
-                "m_Id": "8cb7793e38124380a44425bd5fc82380"
             }
         ]
     },
@@ -592,40 +575,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "069c396c412f472da7e8284329528db0",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Smoothness",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "56c0d421837444d3997ddcbac07d8d88"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Smoothness"
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
     "m_ObjectId": "087a6f0ad909495ea3fc5e0d77b9afc5",
     "m_Id": 2,
@@ -666,6 +615,31 @@
         "b": 0.5,
         "a": 1.0
     }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
+    "m_ObjectId": "0b324e03d5fb428fa44d693ebcf653eb",
+    "m_Guid": {
+        "m_GuidSerialized": "c224b647-4878-441b-81f6-762da065cfc4"
+    },
+    "m_Name": "Shadows Cascade",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Shadows Cascade",
+    "m_DefaultReferenceName": "_SHADOWS_CASCADE",
+    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_KeywordType": 0,
+    "m_KeywordDefinition": 1,
+    "m_KeywordScope": 0,
+    "m_KeywordStages": 63,
+    "m_Entries": [],
+    "m_Value": 1,
+    "m_IsEditable": true
 }
 
 {
@@ -767,6 +741,31 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
+    "m_ObjectId": "1da28ca55a624361b7bf627f762ea626",
+    "m_Guid": {
+        "m_GuidSerialized": "4a0adf96-d82b-425d-9a2b-0681b6ab64e6"
+    },
+    "m_Name": "Shadows",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Shadows",
+    "m_DefaultReferenceName": "_SHADOWS",
+    "m_OverrideReferenceName": "MAIN_LIGHT_CALCULATE_SHADOWS",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_KeywordType": 0,
+    "m_KeywordDefinition": 1,
+    "m_KeywordScope": 0,
+    "m_KeywordStages": 63,
+    "m_Entries": [],
+    "m_Value": 1,
+    "m_IsEditable": true
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "20750aab38bd4e739d8375dc2ad412c9",
@@ -828,40 +827,6 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "257408cf1d7c4e338c488c54a05eaa26",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.NormalTS",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "fb521d995f9a431a9c20410400c13bd3"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.NormalTS"
 }
 
 {
@@ -1316,21 +1281,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "56c0d421837444d3997ddcbac07d8d88",
-    "m_Id": 0,
-    "m_DisplayName": "Smoothness",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Smoothness",
-    "m_StageCapability": 2,
-    "m_Value": 0.5,
-    "m_DefaultValue": 0.5,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "56e2bcac20b94c8bb462092895e9f2a9",
     "m_Id": 2,
     "m_DisplayName": "Out",
@@ -1513,6 +1463,9 @@
             "m_Id": "daf00d5b235743b98b97e6547bd5702d"
         },
         {
+            "m_Id": "fb9f8f2c12ff4cecb0d04c9729ac69c1"
+        },
+        {
             "m_Id": "b1cd4d253fc7485da14267ebfeec550e"
         },
         {
@@ -1549,7 +1502,8 @@
         "05417ffd-3333-418d-8112-367ec1544c17",
         "dfd4614c-8676-4727-98b1-33cbc41c2584",
         "f4c3eb80-2c7c-4e08-a14a-1f038aaec35f",
-        "81edd143-4e15-4e44-a0db-f3a20f31d05d"
+        "81edd143-4e15-4e44-a0db-f3a20f31d05d",
+        "b94d9b26-6a00-4d2a-bf4c-759391005a8f"
     ],
     "m_PropertyIds": [
         1453157262,
@@ -1560,44 +1514,11 @@
         766904974,
         -672839066,
         -434691113,
-        814380537
+        814380537,
+        -397886200
     ],
     "m_Dropdowns": [],
     "m_DropdownSelectedEntries": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "6079c2f81db342dc8cb04f9b14e1af19",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Emission",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "a3c4c008a5504f069ad9cfde1b26005d"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Emission"
 }
 
 {
@@ -1685,6 +1606,24 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "6a628d1ead2d436c96e8e8e39f2b2663",
+    "m_Name": "Shadows",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "1da28ca55a624361b7bf627f762ea626"
+        },
+        {
+            "m_Id": "0b324e03d5fb428fa44d693ebcf653eb"
+        },
+        {
+            "m_Id": "79943f6c050e4cf0a20051379c88eb72"
+        }
+    ]
 }
 
 {
@@ -1914,6 +1853,31 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
+    "m_ObjectId": "79943f6c050e4cf0a20051379c88eb72",
+    "m_Guid": {
+        "m_GuidSerialized": "57469897-f5b3-4f61-9fc9-4f80ca8401bd"
+    },
+    "m_Name": "Soft Shadows",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Soft Shadows",
+    "m_DefaultReferenceName": "_SOFT_SHADOWS",
+    "m_OverrideReferenceName": "_SHADOWS_SOFT",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_KeywordType": 0,
+    "m_KeywordDefinition": 1,
+    "m_KeywordScope": 0,
+    "m_KeywordStages": 63,
+    "m_Entries": [],
+    "m_Value": 1,
+    "m_IsEditable": true
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "7c349d1550114935b0245d1c6b7ec133",
@@ -2125,40 +2089,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "8cb7793e38124380a44425bd5fc82380",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Occlusion",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "ad89e70c99354b42a197c8dc66380a25"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Occlusion"
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Internal.BooleanShaderProperty",
     "m_ObjectId": "907d20b4273e4d96a3bbd752dc21b5cb",
     "m_Guid": {
@@ -2178,16 +2108,6 @@
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
     "m_Value": false
-}
-
-{
-    "m_SGVersion": 2,
-    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
-    "m_ObjectId": "90c89b141c2b476ea040c55da52f6a79",
-    "m_WorkflowMode": 1,
-    "m_NormalDropOffSpace": 0,
-    "m_ClearCoat": false,
-    "m_BlendModePreserveSpecular": true
 }
 
 {
@@ -2321,36 +2241,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
-    "m_ObjectId": "a3c4c008a5504f069ad9cfde1b26005d",
-    "m_Id": 0,
-    "m_DisplayName": "Emission",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Emission",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": [],
-    "m_ColorMode": 1,
-    "m_DefaultColor": {
-        "r": 0.0,
-        "g": 0.0,
-        "b": 0.0,
-        "a": 1.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "a3ff2e89278f472ab923fdc03224d39e",
     "m_Group": {
@@ -2463,21 +2353,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "ad89e70c99354b42a197c8dc66380a25",
-    "m_Id": 0,
-    "m_DisplayName": "Ambient Occlusion",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Occlusion",
-    "m_StageCapability": 2,
-    "m_Value": 1.0,
-    "m_DefaultValue": 1.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
     "m_ObjectId": "b1cd4d253fc7485da14267ebfeec550e",
     "m_Id": 1689957513,
@@ -2488,40 +2363,6 @@
     "m_StageCapability": 2,
     "m_Value": true,
     "m_DefaultValue": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "b3755e8dec5f4c06bd2100508ac05677",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Metallic",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "d9ca700484cb49a89943a93b3a30fb9e"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Metallic"
 }
 
 {
@@ -2712,7 +2553,7 @@
     "m_ObjectId": "c37fd2ae763947ea8cfe3b8759ee0ae8",
     "m_Datas": [],
     "m_ActiveSubTarget": {
-        "m_Id": "90c89b141c2b476ea040c55da52f6a79"
+        "m_Id": "d803d97430344704807342b9c17899fa"
     },
     "m_AllowMaterialOverride": false,
     "m_SurfaceType": 0,
@@ -2770,18 +2611,9 @@
 }
 
 {
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "d9ca700484cb49a89943a93b3a30fb9e",
-    "m_Id": 0,
-    "m_DisplayName": "Metallic",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Metallic",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
+    "m_SGVersion": 2,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalUnlitSubTarget",
+    "m_ObjectId": "d803d97430344704807342b9c17899fa"
 }
 
 {
@@ -3016,26 +2848,16 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
-    "m_ObjectId": "fb521d995f9a431a9c20410400c13bd3",
-    "m_Id": 0,
-    "m_DisplayName": "Normal (Tangent Space)",
+    "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
+    "m_ObjectId": "fb9f8f2c12ff4cecb0d04c9729ac69c1",
+    "m_Id": -397886200,
+    "m_DisplayName": "Shadow Texture",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "NormalTS",
+    "m_ShaderOutputName": "_Shadow_Texture",
     "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": [],
-    "m_Space": 3
+    "m_Value": false,
+    "m_DefaultValue": false
 }
 
 {

--- a/Assets/Shaders/WobbleDisplacement.shadergraph
+++ b/Assets/Shaders/WobbleDisplacement.shadergraph
@@ -31,7 +31,17 @@
             "m_Id": "44db696c418643b8bd234f31a652a35b"
         }
     ],
-    "m_Keywords": [],
+    "m_Keywords": [
+        {
+            "m_Id": "052890f34370413f9b22d8e32ca78ea4"
+        },
+        {
+            "m_Id": "5dda473641e74cdcac1a63b82c483df4"
+        },
+        {
+            "m_Id": "cb6e7982aed1493eb505ba63cfd863b8"
+        }
+    ],
     "m_Dropdowns": [],
     "m_CategoryData": [
         {
@@ -45,6 +55,9 @@
         },
         {
             "m_Id": "206b5dbb3cbd4edca551af9e151c48a3"
+        },
+        {
+            "m_Id": "786ca582e8fd4f32b474502fb94e567d"
         }
     ],
     "m_Nodes": [
@@ -59,21 +72,6 @@
         },
         {
             "m_Id": "98e85fa53447436fb591e9259582b45c"
-        },
-        {
-            "m_Id": "257408cf1d7c4e338c488c54a05eaa26"
-        },
-        {
-            "m_Id": "b3755e8dec5f4c06bd2100508ac05677"
-        },
-        {
-            "m_Id": "069c396c412f472da7e8284329528db0"
-        },
-        {
-            "m_Id": "6079c2f81db342dc8cb04f9b14e1af19"
-        },
-        {
-            "m_Id": "8cb7793e38124380a44425bd5fc82380"
         },
         {
             "m_Id": "e06e4f5683e349439e4899590b1a1d86"
@@ -467,21 +465,6 @@
         "m_Blocks": [
             {
                 "m_Id": "98e85fa53447436fb591e9259582b45c"
-            },
-            {
-                "m_Id": "257408cf1d7c4e338c488c54a05eaa26"
-            },
-            {
-                "m_Id": "b3755e8dec5f4c06bd2100508ac05677"
-            },
-            {
-                "m_Id": "069c396c412f472da7e8284329528db0"
-            },
-            {
-                "m_Id": "6079c2f81db342dc8cb04f9b14e1af19"
-            },
-            {
-                "m_Id": "8cb7793e38124380a44425bd5fc82380"
             }
         ]
     },
@@ -506,6 +489,31 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
+    "m_ObjectId": "052890f34370413f9b22d8e32ca78ea4",
+    "m_Guid": {
+        "m_GuidSerialized": "7c9d57ca-fef1-47d2-9a6a-aeabe26ed928"
+    },
+    "m_Name": "Shadows",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Shadows",
+    "m_DefaultReferenceName": "_SHADOWS",
+    "m_OverrideReferenceName": "MAIN_LIGHT_CALCULATE_SHADOWS",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_KeywordType": 0,
+    "m_KeywordDefinition": 1,
+    "m_KeywordScope": 0,
+    "m_KeywordStages": 63,
+    "m_Entries": [],
+    "m_Value": 1,
+    "m_IsEditable": true
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
     "m_ObjectId": "05ec23ce559b44cea620f3d7fb619f50",
@@ -517,40 +525,6 @@
     "m_StageCapability": 3,
     "m_Value": false,
     "m_DefaultValue": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "069c396c412f472da7e8284329528db0",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Smoothness",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "56c0d421837444d3997ddcbac07d8d88"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Smoothness"
 }
 
 {
@@ -696,6 +670,9 @@
             "m_Id": "2ad56d64c3c04bafba4790ca59b730dd"
         },
         {
+            "m_Id": "2e4f547d48c54149b73a9695c98264f4"
+        },
+        {
             "m_Id": "55a198d0c41c4693a74b79f625e88674"
         },
         {
@@ -732,7 +709,8 @@
         "05417ffd-3333-418d-8112-367ec1544c17",
         "dfd4614c-8676-4727-98b1-33cbc41c2584",
         "f4c3eb80-2c7c-4e08-a14a-1f038aaec35f",
-        "81edd143-4e15-4e44-a0db-f3a20f31d05d"
+        "81edd143-4e15-4e44-a0db-f3a20f31d05d",
+        "b94d9b26-6a00-4d2a-bf4c-759391005a8f"
     ],
     "m_PropertyIds": [
         1453157262,
@@ -743,7 +721,8 @@
         766904974,
         -672839066,
         -434691113,
-        814380537
+        814380537,
+        -397886200
     ],
     "m_Dropdowns": [],
     "m_DropdownSelectedEntries": []
@@ -849,6 +828,12 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 2,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalUnlitSubTarget",
+    "m_ObjectId": "15e71fbda4c740afad81f4ad8d5ea15d"
 }
 
 {
@@ -1062,40 +1047,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "257408cf1d7c4e338c488c54a05eaa26",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.NormalTS",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "fb521d995f9a431a9c20410400c13bd3"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.NormalTS"
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "25d2e145795546b1b2d7a49edf364038",
     "m_Id": 2,
@@ -1207,6 +1158,20 @@
     },
     "m_Labels": [],
     "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
+    "m_ObjectId": "2e4f547d48c54149b73a9695c98264f4",
+    "m_Id": -397886200,
+    "m_DisplayName": "Shadow Texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_Shadow_Texture",
+    "m_StageCapability": 2,
+    "m_Value": false,
+    "m_DefaultValue": false
 }
 
 {
@@ -1523,21 +1488,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "56c0d421837444d3997ddcbac07d8d88",
-    "m_Id": 0,
-    "m_DisplayName": "Smoothness",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Smoothness",
-    "m_StageCapability": 2,
-    "m_Value": 0.5,
-    "m_DefaultValue": 0.5,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "56e2bcac20b94c8bb462092895e9f2a9",
     "m_Id": 2,
     "m_DisplayName": "Out",
@@ -1634,37 +1584,28 @@
 }
 
 {
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "6079c2f81db342dc8cb04f9b14e1af19",
-    "m_Group": {
-        "m_Id": ""
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
+    "m_ObjectId": "5dda473641e74cdcac1a63b82c483df4",
+    "m_Guid": {
+        "m_GuidSerialized": "e5ae3ff0-bd50-48bd-851b-730e82792ba5"
     },
-    "m_Name": "SurfaceDescription.Emission",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "a3c4c008a5504f069ad9cfde1b26005d"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
+    "m_Name": "Shadows Cascade",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Shadows Cascade",
+    "m_DefaultReferenceName": "_SHADOWS_CASCADE",
+    "m_OverrideReferenceName": "_MAIN_LIGHT_SHADOWS_CASCADE",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Emission"
+    "m_KeywordType": 0,
+    "m_KeywordDefinition": 1,
+    "m_KeywordScope": 0,
+    "m_KeywordStages": 63,
+    "m_Entries": [],
+    "m_Value": 1,
+    "m_IsEditable": true
 }
 
 {
@@ -1880,6 +1821,24 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "786ca582e8fd4f32b474502fb94e567d",
+    "m_Name": "Shadows",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "052890f34370413f9b22d8e32ca78ea4"
+        },
+        {
+            "m_Id": "cb6e7982aed1493eb505ba63cfd863b8"
+        },
+        {
+            "m_Id": "5dda473641e74cdcac1a63b82c483df4"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.SubtractNode",
     "m_ObjectId": "794f2a8b940e42a8aed9ead6ebe1f8d5",
     "m_Group": {
@@ -2071,50 +2030,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "8cb7793e38124380a44425bd5fc82380",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Occlusion",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "ad89e70c99354b42a197c8dc66380a25"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Occlusion"
-}
-
-{
-    "m_SGVersion": 2,
-    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
-    "m_ObjectId": "90c89b141c2b476ea040c55da52f6a79",
-    "m_WorkflowMode": 1,
-    "m_NormalDropOffSpace": 0,
-    "m_ClearCoat": false,
-    "m_BlendModePreserveSpecular": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
     "m_ObjectId": "969231dc9a75421fa34fe48bc2ad191a",
     "m_Id": 0,
@@ -2264,36 +2179,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
-    "m_ObjectId": "a3c4c008a5504f069ad9cfde1b26005d",
-    "m_Id": 0,
-    "m_DisplayName": "Emission",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Emission",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": [],
-    "m_ColorMode": 1,
-    "m_DefaultColor": {
-        "r": 0.0,
-        "g": 0.0,
-        "b": 0.0,
-        "a": 1.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "a3fc155c14a44e47ac087f8e1c5bb3eb",
     "m_Id": 2,
@@ -2377,21 +2262,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "ad89e70c99354b42a197c8dc66380a25",
-    "m_Id": 0,
-    "m_DisplayName": "Ambient Occlusion",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Occlusion",
-    "m_StageCapability": 2,
-    "m_Value": 1.0,
-    "m_DefaultValue": 1.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "b02939b8191c476590dde54bc0c71710",
     "m_Id": 766904974,
     "m_DisplayName": "Smoothness",
@@ -2415,40 +2285,6 @@
     "m_ShaderOutputName": "Out",
     "m_StageCapability": 3,
     "m_BareResource": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "b3755e8dec5f4c06bd2100508ac05677",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Metallic",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "d9ca700484cb49a89943a93b3a30fb9e"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Metallic"
 }
 
 {
@@ -2572,7 +2408,7 @@
     "m_ObjectId": "c37fd2ae763947ea8cfe3b8759ee0ae8",
     "m_Datas": [],
     "m_ActiveSubTarget": {
-        "m_Id": "90c89b141c2b476ea040c55da52f6a79"
+        "m_Id": "15e71fbda4c740afad81f4ad8d5ea15d"
     },
     "m_AllowMaterialOverride": false,
     "m_SurfaceType": 0,
@@ -2668,6 +2504,31 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
+    "m_ObjectId": "cb6e7982aed1493eb505ba63cfd863b8",
+    "m_Guid": {
+        "m_GuidSerialized": "a3646502-d885-4da0-b186-fbda610e9bae"
+    },
+    "m_Name": "Soft Shadows",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Soft Shadows",
+    "m_DefaultReferenceName": "_SOFT_SHADOWS",
+    "m_OverrideReferenceName": "_SHADOWS_SOFT",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_KeywordType": 0,
+    "m_KeywordDefinition": 1,
+    "m_KeywordScope": 0,
+    "m_KeywordStages": 63,
+    "m_Entries": [],
+    "m_Value": 1,
+    "m_IsEditable": true
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "cb74a997e4974260999f28978dda2e43",
@@ -2745,21 +2606,6 @@
         "z": 0.0,
         "w": 0.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "d9ca700484cb49a89943a93b3a30fb9e",
-    "m_Id": 0,
-    "m_DisplayName": "Metallic",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Metallic",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
 }
 
 {
@@ -2958,29 +2804,5 @@
         "z": 0.0,
         "w": 0.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
-    "m_ObjectId": "fb521d995f9a431a9c20410400c13bd3",
-    "m_Id": 0,
-    "m_DisplayName": "Normal (Tangent Space)",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "NormalTS",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": [],
-    "m_Space": 3
 }
 


### PR DESCRIPTION
- Lobby with steam names
- Ability to start the game where each client controls a unique FPS player
- Player identity properties like steamnames and colors are transfered between scenes 

misc:
- Fix training ground being unenterable
- Fix Jiggle materials using lit instead of the inteded unlit shader

Currently not yet fixed:
Only player 1 has is correctly synced over all clients, I'll fix the rest in a seperate PR