### PR TITLE
Add toggleable crouch, add extra gamepad buttons for zoom+crouch

### DIFF
--- a/Assets/ScriptableObjects/Input/PlayerControls.inputactions
+++ b/Assets/ScriptableObjects/Input/PlayerControls.inputactions
@@ -540,9 +540,27 @@
                     "initialStateCheck": false
                 },
                 {
+                    "name": "CrouchToggle",
+                    "type": "Button",
+                    "id": "8d731947-226e-4543-a97c-a83b3391ea36",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
                     "name": "Zoom",
                     "type": "Button",
                     "id": "03e4cf1a-97d6-4cd2-956e-0a3809664868",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ZoomToggle",
+                    "type": "Button",
+                    "id": "1b173d76-269b-47ac-971a-f7c2a2b9a9a0",
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "",
@@ -716,7 +734,7 @@
                 {
                     "name": "",
                     "id": "14967268-3847-4e31-b556-017d17d7d911",
-                    "path": "<Gamepad>/leftTrigger",
+                    "path": "<Gamepad>/leftShoulder",
                     "interactions": "",
                     "processors": "",
                     "groups": "Gamepad",
@@ -760,18 +778,7 @@
                 {
                     "name": "",
                     "id": "934f0261-5d67-4c99-babd-a34f558f6b2c",
-                    "path": "<Gamepad>/rightStickPress",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Gamepad",
-                    "action": "Zoom",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "8092a7ef-355c-48f6-b000-0d843fc6f278",
-                    "path": "<Gamepad>/buttonNorth",
+                    "path": "<Gamepad>/leftTrigger",
                     "interactions": "",
                     "processors": "",
                     "groups": "Gamepad",
@@ -798,6 +805,50 @@
                     "processors": "",
                     "groups": "Gamepad",
                     "action": "Interact",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "10d91971-d53d-46b9-a9d7-1cd214a97fa4",
+                    "path": "<Gamepad>/rightStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "ZoomToggle",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "769f8717-a4f7-47cc-9ea3-716b5ce90378",
+                    "path": "<Gamepad>/buttonNorth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "ZoomToggle",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5ac8de42-d1b6-4205-8c51-f43460047250",
+                    "path": "<Gamepad>/leftStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "CrouchToggle",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "057e28d0-2037-49e8-ade4-d644fc12679d",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "CrouchToggle",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Scripts/Control&Input/InputManager.cs
+++ b/Assets/Scripts/Control&Input/InputManager.cs
@@ -54,6 +54,7 @@ public class InputManager : MonoBehaviour
     public bool IsMouseAndKeyboard => isMouseAndKeyboard;
 
     public bool ZoomActive = false;
+    public bool CrouchActive = false;
 
     void Start()
     {
@@ -88,8 +89,12 @@ public class InputManager : MonoBehaviour
         playerInput.actions["Fire"].canceled += Fire;
         playerInput.actions["Crouch"].performed += Crouch;
         playerInput.actions["Crouch"].canceled += Crouch;
+        playerInput.actions["CrouchToggle"].performed += CrouchToggle;
+        playerInput.actions["CrouchToggle"].canceled += CrouchToggle;
         playerInput.actions["Zoom"].performed += Zoom;
         playerInput.actions["Zoom"].canceled += Zoom;
+        playerInput.actions["ZoomToggle"].performed += ZoomToggle;
+        playerInput.actions["ZoomToggle"].canceled += ZoomToggle;
         playerInput.actions["Look"].performed += Look;
         playerInput.actions["Look"].canceled += Look;
 
@@ -225,24 +230,40 @@ public class InputManager : MonoBehaviour
 
     private void Crouch(InputAction.CallbackContext ctx)
     {
-        if (ctx.performed) { onCrouchPerformed?.Invoke(ctx); return; }
+        if (ctx.performed) {
+            CrouchActive = true;
+            onCrouchPerformed?.Invoke(ctx);
+            return;
+        }
+        CrouchActive = false;
         onCrouchCanceled?.Invoke(ctx);
+    }
+
+    private void CrouchToggle(InputAction.CallbackContext ctx)
+    {
+        if (ctx.performed)
+        {
+            CrouchActive = !CrouchActive;
+            if (!CrouchActive) { onCrouchCanceled?.Invoke(ctx); return; }
+            onCrouchPerformed?.Invoke(ctx);
+        }
     }
 
     private void Zoom(InputAction.CallbackContext ctx)
     {
-        if (isMouseAndKeyboard)
-        {
-            if (ctx.performed) { 
-                ZoomActive = true;
-                onZoomPerformed?.Invoke(ctx);
-                return; 
-            }
-            ZoomActive = false;
-            onZoomCanceled?.Invoke(ctx);
-            return;
+        if (ctx.performed) 
+        { 
+            ZoomActive = true;
+            onZoomPerformed?.Invoke(ctx);
+            return; 
         }
+        ZoomActive = false;
+        onZoomCanceled?.Invoke(ctx);
+        return;
+    }
 
+    private void ZoomToggle(InputAction.CallbackContext ctx)
+    {
         if (ctx.performed)
         {
             ZoomActive = !ZoomActive;

--- a/Assets/Scripts/Control&Input/PlayerMovement.cs
+++ b/Assets/Scripts/Control&Input/PlayerMovement.cs
@@ -279,15 +279,10 @@ public class PlayerMovement : MonoBehaviour
             gunHolder.transform.localPosition = new Vector3(gunHolder.transform.localPosition.x, localGunHolderHeight, gunHolder.transform.localPosition.z);
         }
 
-        if (ctx.performed)
-        {
+        if (inputManager.CrouchActive)
             StartCrouching();
-        }
-
-        if (ctx.canceled)
-        {
+        else
             StopCrouching();
-        }
     }
 
     private void StartCrouching()


### PR DESCRIPTION
- Add proper toggleable zoom and crouch alternatives
- Left gamepad trigger is now "hold to zoom" instead of "hold to crouch" (as per feedback and agreed upon earlier)
- Gamepad "hold to crouch" is now the previously unbound left gamepad shoulder button (the small one above the trigger)
- East gamepad button and left gamepad stick "push in" is now also toggleable crouch  