### PR TITLE
Make it possible to leave lobbies ++

### DIFF
--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 785370674}
-  m_IndirectSpecularColor: {r: 0.062468532, g: 0.21935716, b: 0.49492905, a: 1}
+  m_IndirectSpecularColor: {r: 0.06230259, g: 0.21924329, b: 0.4949595, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 785370674}
-  m_IndirectSpecularColor: {r: 0.062260266, g: 0.219236, b: 0.49507987, a: 1}
+  m_IndirectSpecularColor: {r: 0.061073616, g: 0.21100084, b: 0.4741943, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -469,17 +469,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e2ad36662a02c3488301a5286b27635, type: 3}
---- !u!114 &204859168 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8335508045275328475, guid: 0e2ad36662a02c3488301a5286b27635, type: 3}
-  m_PrefabInstance: {fileID: 204859167}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fed2c0b01e2cbdd4d8233de825aa123f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &282782751 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: e82874ba34dffc64f840e8d7656aac9b, type: 3}
@@ -3305,6 +3294,22 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 235417824669612353, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 235417824669612353, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 235417824669612353, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 235417824669612353, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 276468201118272434, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -3416,6 +3421,10 @@ PrefabInstance:
     - target: {fileID: 486747976209633982, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -12.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 498461531050094575, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_Name
+      value: Lobby 2
       objectReference: {fileID: 0}
     - target: {fileID: 531660285164481625, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
@@ -3629,6 +3638,30 @@ PrefabInstance:
       propertyPath: m_TargetCamera
       value: 
       objectReference: {fileID: 378774845}
+    - target: {fileID: 943789032350396941, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 943789032350396941, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 943789032350396941, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 943789032350396941, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 943789032350396941, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 943789032350396941, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -507.5
+      objectReference: {fileID: 0}
     - target: {fileID: 947967702778676497, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -3865,6 +3898,10 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: StartTrainingMode
       objectReference: {fileID: 0}
+    - target: {fileID: 1181067044049665963, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_Name
+      value: Lobby 6
+      objectReference: {fileID: 0}
     - target: {fileID: 1191804004005065026, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -4052,7 +4089,7 @@ PrefabInstance:
     - target: {fileID: 1604608621933614529, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
       value: 
-      objectReference: {fileID: 204859168}
+      objectReference: {fileID: 8419046673555529007}
     - target: {fileID: 1604608621933614529, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_CallState
       value: 2
@@ -4079,7 +4116,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1604608621933614529, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
-      value: SteamManager, Assembly-CSharp
+      value: MainMenuController, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 1604608621933614529, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
@@ -4129,6 +4166,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -537.5
       objectReference: {fileID: 0}
+    - target: {fileID: 1657298885383329085, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_Name
+      value: Refresh
+      objectReference: {fileID: 0}
     - target: {fileID: 1660223469657016724, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -4156,6 +4197,30 @@ PrefabInstance:
     - target: {fileID: 1675218394301149987, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1679135724366270735, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1679135724366270735, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1679135724366270735, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 1679135724366270735, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 1679135724366270735, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 1679135724366270735, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -577.5
       objectReference: {fileID: 0}
     - target: {fileID: 1696055670370733696, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
@@ -4259,6 +4324,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1798716306800514998, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1838107283220176535, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1849559135993384378, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
@@ -4549,6 +4618,30 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2582756298937543181, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2582756298937543181, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2582756298937543181, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 2582756298937543181, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 2582756298937543181, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 2582756298937543181, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -437.5
+      objectReference: {fileID: 0}
     - target: {fileID: 2616416916773457360, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -4612,6 +4705,34 @@ PrefabInstance:
     - target: {fileID: 2657767505105540052, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2664239922878481577, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_Name
+      value: Back
+      objectReference: {fileID: 0}
+    - target: {fileID: 2687485270630039707, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2687485270630039707, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2687485270630039707, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2687485270630039707, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 2687485270630039707, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2687485270630039707, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 52.5
       objectReference: {fileID: 0}
     - target: {fileID: 2695645230481434125, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
@@ -5228,6 +5349,30 @@ PrefabInstance:
     - target: {fileID: 3827342388914617230, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3845740983293786697, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3845740983293786697, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3845740983293786697, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3845740983293786697, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 3845740983293786697, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3845740983293786697, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -157.5
       objectReference: {fileID: 0}
     - target: {fileID: 4009555116316095552, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
@@ -5617,6 +5762,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4516325428825466795, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_Name
+      value: Lobby 7
+      objectReference: {fileID: 0}
     - target: {fileID: 4674913341754671156, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 4
@@ -5712,6 +5861,10 @@ PrefabInstance:
     - target: {fileID: 4783037583379668445, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
       value: MoveToDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 4792186290092316392, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_Name
+      value: Lobby 1
       objectReference: {fileID: 0}
     - target: {fileID: 4833381458767646314, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
@@ -6637,6 +6790,30 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6300764312965444613, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6300764312965444613, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6300764312965444613, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 6300764312965444613, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 6300764312965444613, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 6300764312965444613, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -297.5
+      objectReference: {fileID: 0}
     - target: {fileID: 6453872069080298976, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -6660,6 +6837,10 @@ PrefabInstance:
     - target: {fileID: 6453872069080298976, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6520677190774373836, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_Name
+      value: Lobby 3
       objectReference: {fileID: 0}
     - target: {fileID: 6522862948763284863, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
@@ -6717,6 +6898,30 @@ PrefabInstance:
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6690626696266284578, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6690626696266284578, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6690626696266284578, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6690626696266284578, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 6690626696266284578, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6690626696266284578, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -17.5
+      objectReference: {fileID: 0}
     - target: {fileID: 6766439522081277606, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -6792,6 +6997,30 @@ PrefabInstance:
     - target: {fileID: 6823384234156119955, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879461112605939948, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879461112605939948, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879461112605939948, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879461112605939948, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879461112605939948, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879461112605939948, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -367.5
       objectReference: {fileID: 0}
     - target: {fileID: 6899239940400563305, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
@@ -6856,7 +7085,7 @@ PrefabInstance:
     - target: {fileID: 7039267676045984817, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 204859168}
+      objectReference: {fileID: 8419046673555529007}
     - target: {fileID: 7039267676045984817, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
@@ -6875,7 +7104,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7039267676045984817, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: SteamManager, Assembly-CSharp
+      value: MainMenuController, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 7039267676045984817, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
@@ -7061,6 +7290,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7261204275132391843, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_Name
+      value: Lobby 4
+      objectReference: {fileID: 0}
     - target: {fileID: 7327452833946990020, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -7131,6 +7364,22 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7411888361286323024, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7436320337765929960, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7436320337765929960, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7436320337765929960, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7436320337765929960, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7471489597355220389, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
@@ -7225,6 +7474,30 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
+    - target: {fileID: 7622954007162136682, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7622954007162136682, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7622954007162136682, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 7622954007162136682, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 7622954007162136682, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 7622954007162136682, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -227.5
+      objectReference: {fileID: 0}
     - target: {fileID: 7694880668175484972, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -7265,6 +7538,10 @@ PrefabInstance:
       propertyPath: m_text
       value: Exclusive Fullscreen
       objectReference: {fileID: 0}
+    - target: {fileID: 7839909872239807818, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_Name
+      value: Lobby 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7856711457993785725, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -7320,6 +7597,10 @@ PrefabInstance:
     - target: {fileID: 7912216628995037509, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8029307474075020164, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_Name
+      value: Lobby 0
       objectReference: {fileID: 0}
     - target: {fileID: 8060395404070400720, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_fontSize
@@ -7340,6 +7621,30 @@ PrefabInstance:
     - target: {fileID: 8073145140782095062, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8157550652329821006, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8157550652329821006, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8157550652329821006, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8157550652329821006, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8157550652329821006, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8157550652329821006, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -87.5
       objectReference: {fileID: 0}
     - target: {fileID: 8159374693704537334, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 785370674}
-  m_IndirectSpecularColor: {r: 0.062290687, g: 0.21925586, b: 0.49511063, a: 1}
+  m_IndirectSpecularColor: {r: 0.062428594, g: 0.2193167, b: 0.49494907, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 785370674}
-  m_IndirectSpecularColor: {r: 0.06230259, g: 0.21924329, b: 0.4949595, a: 1}
+  m_IndirectSpecularColor: {r: 0.06250055, g: 0.21941076, b: 0.49502376, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 785370674}
-  m_IndirectSpecularColor: {r: 0.062451348, g: 0.21931733, b: 0.49487647, a: 1}
+  m_IndirectSpecularColor: {r: 0.062468532, g: 0.21935716, b: 0.49492905, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 785370674}
-  m_IndirectSpecularColor: {r: 0.06250055, g: 0.21941076, b: 0.49502376, a: 1}
+  m_IndirectSpecularColor: {r: 0.062260266, g: 0.219236, b: 0.49507987, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 785370674}
-  m_IndirectSpecularColor: {r: 0.061073616, g: 0.21100084, b: 0.4741943, a: 1}
+  m_IndirectSpecularColor: {r: 0.062290687, g: 0.21925586, b: 0.49511063, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
+++ b/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Mirror;
-using OperatorExtensions;
 using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -651,12 +650,18 @@ public class Peer2PeerTransport : NetworkManager
         StartCoroutine(WaitAndInitializeFPSPlayer(message));
     }
 
-    private void UpdateIdentityFromDetails(PlayerIdentity identity, PlayerDetails playerDetails)
+    // TODO move this somewhere else?
+    public static string PlayerNameWithIndex(PlayerDetails playerDetails)
     {
         var playerName = playerDetails.name;
         if (players.Values.Count(p => p.steamID == playerDetails.steamID) > 1)
             playerName = $"{playerName} {playerDetails.localInputID + 1}";
-        identity.UpdateFromDetails(playerDetails, playerName);
+        return playerName;
+    }
+
+    private void UpdateIdentityFromDetails(PlayerIdentity identity, PlayerDetails playerDetails)
+    {
+        identity.UpdateFromDetails(playerDetails, PlayerNameWithIndex(playerDetails));
     }
 
     private IEnumerator WaitAndInitializeFPSPlayer(InitializePlayerMessage message)

--- a/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
+++ b/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
@@ -222,6 +222,8 @@ public class Peer2PeerTransport : NetworkManager
     public override void OnStopServer()
     {
         Debug.Log("Stopped server");
+        if (SteamManager.IsSteamActive && SteamManager.Singleton.IsInLobby)
+            SteamManager.Singleton.LeaveLobby();
         ResetState();
     }
 

--- a/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
+++ b/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
@@ -133,6 +133,7 @@ public class Peer2PeerTransport : NetworkManager
 
     private static Dictionary<uint, PlayerDetails> players = new();
     public static int NumPlayers => players.Count;
+    public const int MaxPlayers = 4;
     public static IEnumerable<PlayerDetails> PlayerDetails => players.Values;
 
     private static List<uint> localPlayerIds = new();
@@ -337,7 +338,7 @@ public class Peer2PeerTransport : NetworkManager
     {
         // Avoid adding more than the four allowed players
         // TODO prevent this in some other more sustainable way :)))))
-        if (NumPlayers >= 4)
+        if (NumPlayers >= MaxPlayers)
             return;
 
         // Register connection
@@ -436,7 +437,7 @@ public class Peer2PeerTransport : NetworkManager
 
     private void AddAiPlayers()
     {
-        for (var i = players.Count; i < 4; i++)
+        for (var i = players.Count; i < MaxPlayers; i++)
         {
             var details = new PlayerDetails
             {

--- a/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
+++ b/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
@@ -633,10 +633,16 @@ public class Peer2PeerTransport : NetworkManager
         var prefab = spawnPrefabs[prefabIndex + prefabIndexOffset];
         var player = Instantiate(prefab, spawnPoint.position, spawnPoint.rotation);
         player.GetComponent<PlayerManager>().id = message.id;
-        if (playerDetails.type is not PlayerType.AI && playerDetails.localInputID == 0)
+
+        // Spawn player, setting it as the player for a connection only for the first local player for each connection
+        var isNotAI = playerDetails.type is not PlayerType.AI;
+        var isFirstLocalPlayer = playerDetails.localInputID == 0;
+        var isNotDisconnected = playerDetails.type is not PlayerType.Remote || connectedPlayers.Contains(playerDetails.id);
+        if (isNotAI && isFirstLocalPlayer && isNotDisconnected)
             NetworkServer.AddPlayerForConnection(connection, player);
         else
             NetworkServer.Spawn(player, connection);
+
         NetworkServer.SendToAll(new InitializePlayerMessage(message.id, spawnPoint.position, spawnPoint.rotation));
     }
 

--- a/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
+++ b/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
@@ -304,10 +304,17 @@ public class Peer2PeerTransport : NetworkManager
     private static IEnumerator WaitAndSwitchToTrainingMode()
     {
         LoadingScreen.Singleton.Show();
+
+        // Wait for player details to be populated
         while (!NetworkClient.isConnected && !singleton.isNetworkActive && players.Count < PlayerInputManagerController.Singleton.LocalPlayerInputs.Count)
             yield return new WaitForEndOfFrame();
         singleton.ServerChangeScene(Scenes.TrainingMode);
-        // TODO until after spawned
+
+        yield return new WaitForSeconds(LoadingScreen.Singleton.MandatoryDuration);
+
+        // Wait for player(s) to have spawned
+        while (FindObjectsByType<PlayerManager>(FindObjectsSortMode.None).Count() < players.Count)
+            yield return new WaitForEndOfFrame();
         LoadingScreen.Singleton.Hide();
     }
 

--- a/Assets/Scripts/Gamestate/MatchController.cs
+++ b/Assets/Scripts/Gamestate/MatchController.cs
@@ -317,7 +317,9 @@ public class MatchController : MonoBehaviour
         PlayerInputManagerController.Singleton.ChangeInputMaps("Menu");
         SceneManager.LoadSceneAsync(Scenes.Menu);
 
-        if (NetworkServer.active)
+        if (SteamManager.IsSteamActive && SteamManager.Singleton.IsInLobby)
+            SteamManager.Singleton.LeaveLobby();
+        else if (NetworkServer.active)
             NetworkManager.singleton.StopHost();
         else
             NetworkManager.singleton.StopClient();

--- a/Assets/Scripts/Gamestate/MatchController.cs
+++ b/Assets/Scripts/Gamestate/MatchController.cs
@@ -317,11 +317,7 @@ public class MatchController : MonoBehaviour
         PlayerInputManagerController.Singleton.ChangeInputMaps("Menu");
         SceneManager.LoadSceneAsync(Scenes.Menu);
 
-        if (SteamManager.IsSteamActive && SteamManager.Singleton.IsInLobby)
-            SteamManager.Singleton.LeaveLobby();
-        else if (NetworkServer.active)
-            NetworkManager.singleton.StopHost();
-        else
-            NetworkManager.singleton.StopClient();
+        // TODO go back to lobby instead
+        NetworkManager.singleton.StopHost();
     }
 }

--- a/Assets/Scripts/LoadingScreen.cs
+++ b/Assets/Scripts/LoadingScreen.cs
@@ -33,7 +33,6 @@ public class LoadingScreen : MonoBehaviour
     [SerializeField] private float normalRotationSpeed = 60;
     [SerializeField] private float fastRotationSpeed = 120;
 
-    private float incrementTimer = 360f;
     private float rotationSpeed = 60;
 
     private static int loadingCounter = 0;
@@ -76,13 +75,16 @@ public class LoadingScreen : MonoBehaviour
     private IEnumerator UpdateTimer(float duration)
     {
         var secondsPerChamber = duration / 6f;
+        var chamberCoverageAngle = 360f;
         rotationSpeed = normalRotationSpeed;
+
+        radialTimer.material.SetFloat("_Arc2", chamberCoverageAngle);
 
         for (int i = 0; i < 6; i++)
         {
             yield return new WaitForSeconds(secondsPerChamber);
-            incrementTimer -= 60f;
-            radialTimer.material.SetFloat("_Arc2", incrementTimer);
+            chamberCoverageAngle -= 60f;
+            radialTimer.material.SetFloat("_Arc2", chamberCoverageAngle);
 
             if (i == 4)
             {

--- a/Assets/Scripts/Platforms/PlatformMovement.cs
+++ b/Assets/Scripts/Platforms/PlatformMovement.cs
@@ -39,7 +39,7 @@ public class PlatformMovement : NetworkBehaviour
 
     private void FixedUpdate()
     {
-        if (isServer)
+        if (!isNetworked || isServer)
             MovePlatform();
     }
 

--- a/Assets/Scripts/PlayerSelect/PlayerSelectManager.cs
+++ b/Assets/Scripts/PlayerSelect/PlayerSelectManager.cs
@@ -69,7 +69,7 @@ public class PlayerSelectManager : MonoBehaviour
         var i = 0;
         foreach (var player in Peer2PeerTransport.PlayerDetails)
         {
-            SetupPlayerSelectModels(player.name, player.color, i);
+            SetupPlayerModel(player, i);
             i++;
         }
         for (; i < playerModels.Count; i++)
@@ -86,17 +86,16 @@ public class PlayerSelectManager : MonoBehaviour
     /// <summary>
     /// Called when player is added. Sets the corresponding playermodel to active and fills in the playername in the nametag.
     /// </summary>
-    /// <param name="playerName"></param>
-    /// <param name="color"></param>
-    /// <param name="playerID"></param>
-    public void SetupPlayerSelectModels(string playerName, Color color, int playerID)
+    /// <param name="player"></param>
+    /// <param name="index"></param>
+    public void SetupPlayerModel(PlayerDetails player, int index)
     {
-        playerModels[playerID].GetComponentInChildren<SkinnedMeshRenderer>().material.color = color; // Set player model color
-        playerModels[playerID].SetActive(true); // Show corresponding player model
-        playerModels[playerID].transform.LookAt(new Vector3(playerSelectCam.transform.position.x, playerModels[playerID].transform.position.y, playerSelectCam.transform.position.z)); // Orient player model to look at camera
-        nameTags[playerID].text = playerName;
-        nameTags[playerID].enabled = true;
-        joinText[playerID].enabled = false;
+        playerModels[index].GetComponentInChildren<SkinnedMeshRenderer>().material.color = player.color; // Set player model color
+        playerModels[index].SetActive(true); // Show corresponding player model
+        playerModels[index].transform.LookAt(new Vector3(playerSelectCam.transform.position.x, playerModels[index].transform.position.y, playerSelectCam.transform.position.z)); // Orient player model to look at camera
+        nameTags[index].text = Peer2PeerTransport.PlayerNameWithIndex(player);
+        nameTags[index].enabled = true;
+        joinText[index].enabled = false;
     }
 
     /// <summary>

--- a/Assets/Scripts/PlayerSelect/PlayerSelectManager.cs
+++ b/Assets/Scripts/PlayerSelect/PlayerSelectManager.cs
@@ -2,7 +2,6 @@ using CollectionExtensions;
 using Mirror;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using TMPro;
 using UnityEngine;
 
@@ -24,7 +23,6 @@ public class PlayerSelectManager : MonoBehaviour
     private float maximumTime = 30f;
 
     private PlayerInputManagerController playerInputManagerController;
-    private List<TMP_Text> playerNames = new List<TMP_Text>();
     private List<Animator> playerAnimators = new List<Animator>();
     private List<string> animatorParameters = new List<string>();
     private int cardPeekCounter = 0;
@@ -34,23 +32,36 @@ public class PlayerSelectManager : MonoBehaviour
         for (int i = 0; i < playerModels.Count; i++)
         {
             Vector3 playerPosition = new Vector3(playerModels[i].transform.position.x, 2, playerModels[i].transform.position.z);
-            joinText[i].transform.position = playerPosition;
+            joinText[i].transform.localPosition = Vector3.zero;
+            nameTags[i].transform.position = playerPosition;
         }
     }
 
     private void Start()
     {
         playerInputManagerController = PlayerInputManagerController.Singleton;
-        for (int i = 0; i < playerModels.Count; i++)
+
+        // Find animators and their parameters
+        foreach (var t in playerModels)
         {
-            playerAnimators.Add(playerModels[i].GetComponentInChildren<Animator>()); // Add all animators to list
+            playerAnimators.Add(t.GetComponentInChildren<Animator>());
+        }
+        foreach (var parameter in playerAnimators[0].parameters)
+        {
+            animatorParameters.Add(parameter.name);
         }
 
-        for (int i = 0; i < playerAnimators[0].parameterCount; i++)
-        {
-            animatorParameters.Add(playerAnimators[0].GetParameter(i).name);
-        }
         ((Peer2PeerTransport)NetworkManager.singleton).OnPlayerRecieved += UpdateLobby;
+        ((Peer2PeerTransport)NetworkManager.singleton).OnPlayerRemoved += UpdateLobby;
+    }
+
+    private void OnDestroy()
+    {
+        if (NetworkManager.singleton)
+        {
+            ((Peer2PeerTransport)NetworkManager.singleton).OnPlayerRecieved -= UpdateLobby;
+            ((Peer2PeerTransport)NetworkManager.singleton).OnPlayerRemoved -= UpdateLobby;
+        }
     }
 
     public void UpdateLobby()
@@ -61,9 +72,13 @@ public class PlayerSelectManager : MonoBehaviour
             SetupPlayerSelectModels(player.name, player.color, i);
             i++;
         }
+        for (; i < playerModels.Count; i++)
+        {
+            DisablePlayerModel(i);
+        }
     }
 
-    public void UpdateLobby(PlayerDetails details)
+    private void UpdateLobby(PlayerDetails details)
     {
         UpdateLobby();
     }
@@ -79,32 +94,22 @@ public class PlayerSelectManager : MonoBehaviour
         playerModels[playerID].GetComponentInChildren<SkinnedMeshRenderer>().material.color = color; // Set player model color
         playerModels[playerID].SetActive(true); // Show corresponding player model
         playerModels[playerID].transform.LookAt(new Vector3(playerSelectCam.transform.position.x, playerModels[playerID].transform.position.y, playerSelectCam.transform.position.z)); // Orient player model to look at camera
-        SetPlayerNameTag(playerModels[playerID], playerName, playerID); // Create and display player nametag
+        nameTags[playerID].text = playerName;
+        nameTags[playerID].enabled = true;
         joinText[playerID].enabled = false;
     }
 
     /// <summary>
-    /// Fills in the playername and positions it.
+    /// Called when player is removed. Stops displaying the affected player.
     /// </summary>
-    /// <param name="player"></param>
-    /// <param name="playerName"></param>
     /// <param name="playerID"></param>
-    public void SetPlayerNameTag(GameObject player, string playerName, int playerID)
+    public void DisablePlayerModel(int playerID)
     {
-        // Check if nameTag exists already
-        bool nameExists = playerNames.Any(x => x.name == playerName);
-
-        // If it doesn't, create new nametag based on player name
-        if (!nameExists)
-        {
-            Vector3 playerPosition = new Vector3(player.transform.position.x, 2, player.transform.position.z);
-
-            TMP_Text name = nameTags[playerID];
-            name.transform.position = playerPosition; // Sets the nametag position over the head of the player model
-            name.text = playerName; // Sets the text of the nametag
-            playerNames.Add(name); // Adds TMP_text object to list for monitoring
-        }
+        playerModels[playerID].SetActive(false);
+        nameTags[playerID].enabled = false;
+        joinText[playerID].enabled = true;
     }
+
 
     /// <summary>
     /// Stops the coroutine responsible for animating players in playerSelectMenu. To be called by "Start" in main menu.
@@ -176,10 +181,5 @@ public class PlayerSelectManager : MonoBehaviour
             }
             yield return new WaitForSeconds(Random.Range(minimumTime, maximumTime));
         }
-    }
-
-    private void OnDestroy()
-    {
-        ((Peer2PeerTransport)NetworkManager.singleton).OnPlayerRecieved -= UpdateLobby;
     }
 }

--- a/Assets/Scripts/UI/ClientLobby.cs
+++ b/Assets/Scripts/UI/ClientLobby.cs
@@ -9,7 +9,6 @@ public class ClientLobby : MonoBehaviour
     private Transform environmentCamera;
     [SerializeField]
     private Transform lobbyPosition;
-    private int playerCount = 0;
 
     void Start()
     {
@@ -19,12 +18,11 @@ public class ClientLobby : MonoBehaviour
 
     public void QuitLobby()
     {
-        Peer2PeerTransport.singleton.StopClient();
+        NetworkManager.singleton.StopClient();
     }
 
     private void AddPlayer(PlayerDetails details)
     {
-        playerSelect.SetupPlayerSelectModels(details.name, details.color, playerCount);
-        playerCount++;
+        playerSelect.UpdateLobby();
     }
 }

--- a/Assets/Scripts/UI/LobbyListMenu.cs
+++ b/Assets/Scripts/UI/LobbyListMenu.cs
@@ -9,10 +9,17 @@ public class LobbyListMenu : MonoBehaviour
 {
     [SerializeField]
     private Button[] lobbies;
+
     private const string defaultMessage = "No lobby found...";
+
     void Start()
     {
         SteamManager.Singleton.LobbyListUpdate += LobbyListUpdate;
+    }
+
+    private void OnDestroy()
+    {
+        SteamManager.Singleton.LobbyListUpdate -= LobbyListUpdate;
     }
 
     private void LobbyListUpdate()

--- a/Assets/Scripts/UI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/MainMenu/MainMenuController.cs
@@ -333,6 +333,14 @@ public class MainMenuController : MonoBehaviour
         playerSelectManager.UpdateLobby();
     }
 
+    public void FetchLobbyInfo()
+    {
+        if (!SteamManager.IsSteamActive)
+            return;
+        SteamManager.Singleton.FetchLobbyInfo();
+    }
+
+
     public void LeaveLobby()
     {
         NetworkManager.singleton.StopHost();

--- a/Assets/Scripts/UI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/MainMenu/MainMenuController.cs
@@ -335,10 +335,7 @@ public class MainMenuController : MonoBehaviour
 
     public void LeaveLobby()
     {
-        if (SteamManager.Singleton.IsHosting)
-            SteamManager.Singleton.LeaveLobby();
-        else
-            NetworkManager.singleton.StopHost();
+        NetworkManager.singleton.StopHost();
     }
 
     public void Quit()

--- a/Assets/Scripts/UI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/MainMenu/MainMenuController.cs
@@ -321,6 +321,7 @@ public class MainMenuController : MonoBehaviour
 
     public void StartTrainingMode()
     {
+        PlayerInputManagerController.Singleton.RemoveJoinListener();
         Peer2PeerTransport.StartTrainingMode();
         playerSelectManager.UpdateLobby();
     }

--- a/Assets/Scripts/UI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/MainMenu/MainMenuController.cs
@@ -264,13 +264,6 @@ public class MainMenuController : MonoBehaviour
         galleryMenu.SetPlayerInput(inputManager);
         creditsMenu.SetPlayerInput(inputManager);
         levelSelectManager.SetPlayerInput(inputManager);
-
-        // TODO Remove this once you're sure that UpdateLobby in PlayerSelectManager is called properly (on local joining as well)
-        for (int i = 0; i < playerInputs.Count; i++)
-        {
-            PlayerIdentity playerIdentity = playerInputs[i].GetComponent<PlayerIdentity>();
-            playerSelectManager.SetupPlayerSelectModels(playerIdentity.playerName, playerIdentity.color, i);
-        }
     }
 
     private void PlayUISelectAudio(InputAction.CallbackContext ctx)

--- a/Assets/Scripts/Utils/SteamManager.cs
+++ b/Assets/Scripts/Utils/SteamManager.cs
@@ -222,23 +222,15 @@ public class SteamManager : MonoBehaviour
         if (!isSteamInitialized)
             return;
 
+        Debug.Log("Left steam lobby");
+
         PlayerNames = new();
         PlayerIDs = new();
 
-        // TODO we should be calling this from inside our NetworkManager, probably, and thus not need to stop host/client here!
-        if (IsHosting)
-        {
-            NetworkManager.singleton.StopHost();
-
-            IsHosting = false;
-        }
-        else
-        {
-            if (NetworkManager.singleton.isNetworkActive)
-                NetworkManager.singleton.StopClient();
-        }
-        SteamMatchmaking.LeaveLobby(lobbyID);
+        IsHosting = false;
         IsInLobby = false;
+
+        SteamMatchmaking.LeaveLobby(lobbyID);
     }
 
     public void FetchLobbyInfo()

--- a/Assets/Scripts/Utils/SteamManager.cs
+++ b/Assets/Scripts/Utils/SteamManager.cs
@@ -166,7 +166,7 @@ public class SteamManager : MonoBehaviour
     {
         // TODO verify that the lobby *should* be joined by more players!
         //      and verify that this is run on the server!
-        if (Peer2PeerTransport.NumPlayers >= 4 || Peer2PeerTransport.IsInMatch)
+        if (Peer2PeerTransport.NumPlayers >= Peer2PeerTransport.MaxPlayers || Peer2PeerTransport.IsInMatch)
             return;
         SteamMatchmaking.JoinLobby(callback.m_steamIDLobby);
     }

--- a/Assets/SodiePopper.cs
+++ b/Assets/SodiePopper.cs
@@ -50,6 +50,7 @@ public class SodiePopper : GunBody
     private float lastPlayerDiff = 0f;
 
     private AudioSource audioSource;
+
     [SerializeField]
     private AudioGroup slosh;
     public override void Start()
@@ -99,9 +100,9 @@ public class SodiePopper : GunBody
             if (accelerationDiff - playerDiff * playermovementRelativeAdjustment >= shakeCorrectionReloadThreshold && Time.fixedTime - lastReload > reload_delay)
             {
                 lastReload = Time.fixedTime;
-                if (gunController && gunController.stats.Magazine != gunController.stats.Ammo)
+                if (gunController && gunController.stats.Magazine != gunController.stats.Ammo && audioSource)
                     slosh.Play(audioSource);
-                    
+
                 gunController?.Reload(reload_ammount);
             }
             lastPos = meassurementPoint.position + diff.normalized * offsetMagnitude;


### PR DESCRIPTION
Depends on #661 

Closes #670 
Closes #671 
Closes #662 

# Stuff done
- [x] Leave lobby when you leave the lobby
- [x] Leave lobby when you disconnect
- [x] Leave lobby when match is over (ideally you'd be back in the lobby again ready for a new match)
- [x] Players visually leave/enter lobbies (PlayerSelectManager jank fixed/worked around)
- [x] Clean up lobby leaving code so you rather have OurNetworkManagerThatIsYetToBeRenamed -> SteamManager
- [x] Disconnects during matches don't break the game (presently the dummy left by the escapee is unkillable, likely due to authority issues)
- [x] Show correct names (Player 1, 2, etc) in lobby
- [x] Fix refresh of lobby list after lobby exit or match end
- [x] Show loading screen when entering training mode
- [x] Fix chamber-filling animation on loading screen (it only played once 💀)
- [x] Fix spawnpoint selection (it used player ID, which can be > 3 now)

# Stuff planned but not done in this PR
- Use SetLobbyJoinable(false) to prevent users from joining an ongoing match and so on 