### PR TITLE
Avoid doubly loading menu

### DIFF
--- a/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
+++ b/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
@@ -245,7 +245,6 @@ public class Peer2PeerTransport : NetworkManager
         LoadingScreen.Singleton.Hide();
         MusicTrackManager.Singleton.SwitchTo(MusicType.Menu);
         PlayerInputManagerController.Singleton.ChangeInputMaps("Menu");
-        SceneManager.LoadSceneAsync(Scenes.Menu);
         if (NetworkClient.active)
             StopClient();
         else

--- a/Assets/Scripts/Control&Input/ReturnToMainMenuGate.cs
+++ b/Assets/Scripts/Control&Input/ReturnToMainMenuGate.cs
@@ -19,8 +19,7 @@ public class ReturnToMainMenuGate : MonoBehaviour, Interactable
     {
         PlayerInputManagerController.Singleton.ChangeInputMaps("Menu");
         PlayerInputManagerController.Singleton.LocalPlayerInputs.ForEach(input => input.GetComponent<PlayerIdentity>().ResetItems());
-        // TODO Is this really correct?
+        // Mirror pulls us to the main menu automatically
         NetworkManager.singleton.StopHost();
-        SceneManager.LoadSceneAsync(Scenes.Menu);
     }
 }

--- a/Assets/Scripts/Gamestate/MatchController.cs
+++ b/Assets/Scripts/Gamestate/MatchController.cs
@@ -328,9 +328,8 @@ public class MatchController : NetworkBehaviour
         rounds = new List<Round>();
         MusicTrackManager.Singleton.SwitchTo(MusicType.Menu);
         PlayerInputManagerController.Singleton.ChangeInputMaps("Menu");
-        SceneManager.LoadSceneAsync(Scenes.Menu);
 
-        // TODO go back to lobby instead
+        // Mirror pulls us to the main menu automatically
         NetworkManager.singleton.StopHost();
     }
 }


### PR DESCRIPTION
Removed LoadSceneAsync calls that are performed *for us* by Mirror and thus resulted in some noticeably stutter when returning to the menu from
- the tutorial
- the end of a match
- otherwise disconnecting