### PR TITLE
Registrer connected players correctly

### DIFF
--- a/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
+++ b/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
@@ -360,11 +360,13 @@ public class Peer2PeerTransport : NetworkManager
         {
             isConnectionAlreadyPresent = false;
             connections.Add(connection);
-            connectedPlayers.Add((uint)playerIndex);
         }
+
+        // Register player
         if (!playersForConnection.ContainsKey(connection.connectionId))
             playersForConnection[connection.connectionId] = new();
         playersForConnection[connection.connectionId].Add((uint)playerIndex);
+        connectedPlayers.Add((uint)playerIndex);
 
         // Determine metadata
         var playerType = PlayerType.Local;


### PR DESCRIPTION
The issue with multiple local players on one client was likely due to the connectedPlayers list not being populated with those extra players, making the server think it needed to spawn a disconnected player for them. Whoops.

Closes #688 (I think).
Needs testing to see if it resolves that exact issue.