### PR TITLE
Reset camera rotation/position when spawning players

### DIFF
--- a/Assets/Scenes/CraterTown.unity
+++ b/Assets/Scenes/CraterTown.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 662445327}
-  m_IndirectSpecularColor: {r: 0.06339308, g: 0.22008887, b: 0.49535277, a: 1}
+  m_IndirectSpecularColor: {r: 0.062285002, g: 0.21922584, b: 0.4949425, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -5255,7 +5255,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &974049643
 Transform:
   m_ObjectHideFlags: 0
@@ -8280,7 +8280,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1483779470
 Transform:
   m_ObjectHideFlags: 0
@@ -10808,7 +10808,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1716348243
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
+++ b/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
@@ -771,6 +771,13 @@ public class Peer2PeerTransport : NetworkManager
         {
             Debug.Log($"Spawning local player {playerDetails.id}");
             var input = PlayerInputManagerController.Singleton.LocalPlayerInputs[playerDetails.localInputID];
+
+            // Reset camera transform (it may have been kerfluffled by the spectator cam thingy)
+            input.transform.localPosition = Vector3.zero;
+            input.transform.localRotation = Quaternion.identity;
+            input.PlayerCamera.transform.localRotation = Quaternion.identity;
+            input.PlayerCamera.transform.localPosition = Vector3.zero;
+
             // Make playerInput child of player it's attached to
             input.transform.parent = player.transform;
             // Set received playerInput (and most importantly its camera) at an offset from player's position
@@ -900,6 +907,12 @@ public class Peer2PeerTransport : NetworkManager
         {
             Debug.Log($"Spawning local player {playerDetails.id}");
             var input = PlayerInputManagerController.Singleton.LocalPlayerInputs[playerDetails.localInputID];
+
+            // Reset camera transform (ensuring we don't mess up in weapon building)
+            input.transform.localPosition = Vector3.zero;
+            input.transform.localRotation = Quaternion.identity;
+            input.PlayerCamera.transform.localRotation = Quaternion.identity;
+            input.PlayerCamera.transform.localPosition = Vector3.zero;
 
             // Make playerInput child of player it's attached to
             input.transform.parent = player.transform;

--- a/Assets/Scripts/Gamestate/PlayerIdentity.cs
+++ b/Assets/Scripts/Gamestate/PlayerIdentity.cs
@@ -76,7 +76,7 @@ public class PlayerIdentity : MonoBehaviour
 
     public void UpdateChipSilently(int amount)
     {
-        chips = amount;
+        chips += amount;
     }
 
     public void PerformTransaction(Item item)


### PR DESCRIPTION
This should fix the issue some players have where it does not reset after having been an orbiting spectator camera


(also reminds me that the spawn code needs refactoring, but that's not happening *right now*)