### PR TITLE
Fix negative chip count and multibidding AIs

### DIFF
--- a/Assets/Scripts/Auction/BiddingPlatform.cs
+++ b/Assets/Scripts/Auction/BiddingPlatform.cs
@@ -1,5 +1,4 @@
 using Mirror;
-using Org.BouncyCastle.Tls;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;

--- a/Assets/Scripts/Gamestate/PlayerIdentity.cs
+++ b/Assets/Scripts/Gamestate/PlayerIdentity.cs
@@ -60,7 +60,16 @@ public class PlayerIdentity : MonoBehaviour
     public void UpdateChip(int amount)
     {
         if (amount == 0) return;
-        chips += amount;
+        if (chips + amount < 0)
+        {
+            Debug.LogWarning($"Player {id} {ToColorString()} almost got negative chips {chips + amount}");
+            // Safeguard against cheating by locking chip amount to 0 when this sort of bug appears.
+            chips = 0;
+        }
+        else
+        {
+            chips += amount;
+        }
 
         onChipChange?.Invoke(chips);
 


### PR DESCRIPTION
- Fix negative chip count by ensuring that we _can_ bid in both the command and client RPC
- Fix AIs being able to cash out lots of chips instantly by rewriting their code to only perform bids once per evaluation

Closes #698 