### PR TITLE
Move the ammobox that was too high down

### DIFF
--- a/Assets/Scenes/CraterTown.unity
+++ b/Assets/Scenes/CraterTown.unity
@@ -547,76 +547,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
   m_PrefabInstance: {fileID: 33676545}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &33703950
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1849558747}
-    m_Modifications:
-    - target: {fileID: 789647354167288699, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_Name
-      value: CollectableAmmo (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1208524406475745194, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.51
-      objectReference: {fileID: 0}
-    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 9.54
-      objectReference: {fileID: 0}
-    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 6.9509277
-      objectReference: {fileID: 0}
-    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -27.11
-      objectReference: {fileID: 0}
-    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
---- !u!4 &33703951 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
-  m_PrefabInstance: {fileID: 33703950}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &57237928
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2366,6 +2296,72 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4961497418944442742, guid: 784354c8bf6b1bd478807b1f52b33bbe, type: 3}
   m_PrefabInstance: {fileID: 480836147}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &498637705
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1849558747}
+    m_Modifications:
+    - target: {fileID: 789647354167288699, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_Name
+      value: CollectableAmmo
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.552002
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.8252335
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -26.85701
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+--- !u!4 &498637706 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8525719441673604141, guid: 9fbe586f58f294549832f177b24aff8b, type: 3}
+  m_PrefabInstance: {fileID: 498637705}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &511965792
 PrefabInstance:
@@ -11497,10 +11493,10 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1707916422}
-  - {fileID: 33703951}
   - {fileID: 241661207}
   - {fileID: 33676546}
   - {fileID: 1384673533}
+  - {fileID: 498637706}
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
The child transform was moved, making it appear higher up than it should be

it's this one: (corrected version)
![image](https://github.com/hackerspace-ntnu/Red-Planet-Rampage/assets/44986729/a15a7d28-5b31-4215-a523-765a94b1568c)

~~now that I think about it, didn't I actually see this w/o the ammo box body? I thought I had the dancer~~ 🤔 
nvm, forgot that I was spectating the bots