### PR TITLE
Add description to lobby modes, fix blank back button text

### DIFF
--- a/Assets/Prefabs/UI/Menus/GamemodeMenu.prefab
+++ b/Assets/Prefabs/UI/Menus/GamemodeMenu.prefab
@@ -1334,14 +1334,17 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7072107538278606930, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4310712212055511701}
   m_SourcePrefab: {fileID: 100100000, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
 --- !u!114 &2272621449971197888 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1543121137935169886, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 784678933708856990}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 7549881267706640076}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
@@ -1352,6 +1355,40 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5877506774103653876, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 784678933708856990}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &7549881267706640076 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7072107538278606930, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
+  m_PrefabInstance: {fileID: 784678933708856990}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4310712212055511701
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7549881267706640076}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 2746609134975766644}
+          m_TargetAssemblyTypeName: GamemodeSelectMenu, Assembly-CSharp
+          m_MethodName: ClearText
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1001 &1859857838337200592
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Menus/LobbySelect.prefab
+++ b/Assets/Prefabs/UI/Menus/LobbySelect.prefab
@@ -1,5 +1,347 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &732774639845960104
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8417563094588920012}
+  - component: {fileID: 2245020125742723085}
+  - component: {fileID: 1863167473620340853}
+  - component: {fileID: 4538241882800251448}
+  m_Layer: 5
+  m_Name: Name
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8417563094588920012
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 732774639845960104}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6776455189265466058}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2245020125742723085
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 732774639845960104}
+  m_CullTransparentMesh: 1
+--- !u!114 &1863167473620340853
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 732774639845960104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: First to 30 chips
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: aa99fff0688574ba78204625170fa6e0, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: a5dba56b90a3ca6978a283b93ad4fe3f, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 60
+  m_fontSizeBase: 60
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &4538241882800251448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 732774639845960104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: 600
+  m_PreferredHeight: 40
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &1726402100873288605
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4929066825823644209}
+  - component: {fileID: 1721552791899101430}
+  m_Layer: 5
+  m_Name: Holder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4929066825823644209
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1726402100873288605}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6090067780547738498}
+  - {fileID: 8187298975425968679}
+  m_Father: {fileID: 7055458770637592391}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1920, y: 675}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1721552791899101430
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1726402100873288605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 60
+    m_Right: 60
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 20
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &2975654531877517708
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6776455189265466058}
+  - component: {fileID: 2020614591181683479}
+  - component: {fileID: 6893020488750688176}
+  - component: {fileID: 6118297250199917863}
+  - component: {fileID: 5527761938481951987}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6776455189265466058
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2975654531877517708}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8417563094588920012}
+  - {fileID: 314865285027502303}
+  m_Father: {fileID: 8187298975425968679}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2020614591181683479
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2975654531877517708}
+  m_CullTransparentMesh: 1
+--- !u!114 &6893020488750688176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2975654531877517708}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.58431375, g: 0.2784314, b: 0.2784314, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 428e9565249fc4246aabc9f5ecc00df9, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6118297250199917863
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2975654531877517708}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 60
+    m_Right: 60
+    m_Top: 40
+    m_Bottom: 40
+  m_ChildAlignment: 4
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &5527761938481951987
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2975654531877517708}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e19747de3f5aca642ab2be37e372fb86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
+  m_EffectDistance: {x: 10, y: -10}
+  m_UseGraphicAlpha: 1
 --- !u!1 &3041369311159645949
 GameObject:
   m_ObjectHideFlags: 0
@@ -11,6 +353,7 @@ GameObject:
   - component: {fileID: 7055458770637592391}
   - component: {fileID: 6132072849916996996}
   - component: {fileID: 2735815480915449081}
+  - component: {fileID: 3583328391671930842}
   m_Layer: 5
   m_Name: LobbySelect
   m_TagString: Untagged
@@ -31,7 +374,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3527170424392536363}
-  - {fileID: 6090067780547738498}
+  - {fileID: 4929066825823644209}
   m_Father: {fileID: 0}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -74,6 +417,24 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &3583328391671930842
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3041369311159645949}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c86e20c1de66f6549b9480a0665290eb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  queueButton: {fileID: 466533435504570254}
+  friendsButton: {fileID: 1419964769890973388}
+  localButton: {fileID: 5910931854525475931}
+  title: {fileID: 1863167473620340853}
+  description: {fileID: 942340396842827908}
+  mainMenuController: {fileID: 0}
 --- !u!1 &4279875055056366284
 GameObject:
   m_ObjectHideFlags: 0
@@ -108,13 +469,13 @@ RectTransform:
   - {fileID: 6291501560300597862}
   - {fileID: 1656343962051143921}
   - {fileID: 498079454081798691}
-  m_Father: {fileID: 7055458770637592391}
+  m_Father: {fileID: 4929066825823644209}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 600}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &3401088317016714797
 MonoBehaviour:
@@ -149,8 +510,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
-    m_Left: 50
-    m_Right: 50
+    m_Left: 0
+    m_Right: 0
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 4
@@ -320,6 +681,239 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7089956871562613364
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 314865285027502303}
+  - component: {fileID: 4375647887225147008}
+  - component: {fileID: 942340396842827908}
+  - component: {fileID: 6123626224536220618}
+  m_Layer: 5
+  m_Name: Description
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &314865285027502303
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7089956871562613364}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6776455189265466058}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4375647887225147008
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7089956871562613364}
+  m_CullTransparentMesh: 1
+--- !u!114 &942340396842827908
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7089956871562613364}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Be the first to win a round with 30 chips!
+
+    Players carry up to 30
+    chips at a time and receive limited chip rewards. Spend your chips strategically
+    and outsmart your opponents.'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 443a3fff53ecf4fd3a43913da28b13bb, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: 90fcafcc23313da2f9e41e1fa44a436a, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 42
+  m_fontSizeBase: 42
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &6123626224536220618
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7089956871562613364}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: 500
+  m_PreferredHeight: 250
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &7432194893351791575
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8187298975425968679}
+  - component: {fileID: 8710176320768194031}
+  - component: {fileID: 1330761848958238386}
+  m_Layer: 5
+  m_Name: Description
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8187298975425968679
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7432194893351791575}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6776455189265466058}
+  m_Father: {fileID: 4929066825823644209}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8710176320768194031
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7432194893351791575}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 50
+    m_Right: 50
+    m_Top: 100
+    m_Bottom: 100
+  m_ChildAlignment: 4
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!222 &1330761848958238386
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7432194893351791575}
+  m_CullTransparentMesh: 1
 --- !u!1001 &495112356396666770
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -422,7 +1016,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3765489543879290160, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
       propertyPath: m_text
-      value: Local
+      value: Friends Only
       objectReference: {fileID: 0}
     - target: {fileID: 3765489543879290160, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
       propertyPath: m_fontSize
@@ -514,19 +1108,22 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7072107538278606930, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
       propertyPath: m_Name
-      value: Private
+      value: Friends Only
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7072107538278606930, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7820148280665480704}
   m_SourcePrefab: {fileID: 100100000, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
 --- !u!114 &1419964769890973388 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1543121137935169886, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 495112356396666770}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 7276640824234567616}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
@@ -537,7 +1134,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4086770535158334872, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 495112356396666770}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 7276640824234567616}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -548,6 +1145,54 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5877506774103653876, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 495112356396666770}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &7276640824234567616 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7072107538278606930, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
+  m_PrefabInstance: {fileID: 495112356396666770}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7820148280665480704
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7276640824234567616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 3583328391671930842}
+          m_TargetAssemblyTypeName: LobbySelect, Assembly-CSharp
+          m_MethodName: SetTitle
+          m_Mode: 5
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: Friend lobby
+            m_BoolArgument: 0
+          m_CallState: 2
+        - m_Target: {fileID: 3583328391671930842}
+          m_TargetAssemblyTypeName: LobbySelect, Assembly-CSharp
+          m_MethodName: SetDescription
+          m_Mode: 5
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: Creates a private lobby that only local players and
+              Steam friends can join. Steam friends can join by using "Join Game"
+              from their Steam friend list.
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1001 &1374497080081520336
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -745,14 +1390,17 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7072107538278606930, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4914463133787348733}
   m_SourcePrefab: {fileID: 100100000, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
 --- !u!114 &466533435504570254 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1543121137935169886, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 1374497080081520336}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 8157740322213297794}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
@@ -763,7 +1411,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4086770535158334872, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 1374497080081520336}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 8157740322213297794}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -774,6 +1422,53 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5877506774103653876, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 1374497080081520336}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &8157740322213297794 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7072107538278606930, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
+  m_PrefabInstance: {fileID: 1374497080081520336}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4914463133787348733
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8157740322213297794}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 3583328391671930842}
+          m_TargetAssemblyTypeName: LobbySelect, Assembly-CSharp
+          m_MethodName: SetTitle
+          m_Mode: 5
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: Queue
+            m_BoolArgument: 0
+          m_CallState: 2
+        - m_Target: {fileID: 3583328391671930842}
+          m_TargetAssemblyTypeName: LobbySelect, Assembly-CSharp
+          m_MethodName: SetDescription
+          m_Mode: 5
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: Automatically search for other players! If you become
+              the host, remember to start the game!
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1001 &5146942896759215365
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -973,19 +1668,70 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7072107538278606930, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 9144864769746070808}
   m_SourcePrefab: {fileID: 100100000, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
 --- !u!224 &1656343962051143921 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5877506774103653876, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 5146942896759215365}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2686591918539341143 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7072107538278606930, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
+  m_PrefabInstance: {fileID: 5146942896759215365}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &9144864769746070808
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2686591918539341143}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 3583328391671930842}
+          m_TargetAssemblyTypeName: LobbySelect, Assembly-CSharp
+          m_MethodName: SetTitle
+          m_Mode: 5
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: Local
+            m_BoolArgument: 0
+          m_CallState: 2
+        - m_Target: {fileID: 3583328391671930842}
+          m_TargetAssemblyTypeName: LobbySelect, Assembly-CSharp
+          m_MethodName: SetDescription
+          m_Mode: 5
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: Creates an offline lobby. Good to use when you have
+              no access to Steam or the internet. Join players by pressing a button
+              on any connected gamepad.
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!114 &5910931854525475931 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1543121137935169886, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 5146942896759215365}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 2686591918539341143}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
@@ -996,7 +1742,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4086770535158334872, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 5146942896759215365}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 2686591918539341143}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -1161,19 +1907,68 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7072107538278606930, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6821556265997462601}
   m_SourcePrefab: {fileID: 100100000, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
 --- !u!224 &498079454081798691 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5877506774103653876, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 6302948046830383063}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &3845438068142393221 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7072107538278606930, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
+  m_PrefabInstance: {fileID: 6302948046830383063}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6821556265997462601
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3845438068142393221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 3583328391671930842}
+          m_TargetAssemblyTypeName: LobbySelect, Assembly-CSharp
+          m_MethodName: SetTitle
+          m_Mode: 5
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+        - m_Target: {fileID: 3583328391671930842}
+          m_TargetAssemblyTypeName: LobbySelect, Assembly-CSharp
+          m_MethodName: SetDescription
+          m_Mode: 5
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!114 &4761102662359094921 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1543121137935169886, guid: e472bbf090cca566cae93eec176f8dff, type: 3}
   m_PrefabInstance: {fileID: 6302948046830383063}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 3845438068142393221}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}

--- a/Assets/Prefabs/UI/Menus/MenuCanvas.prefab
+++ b/Assets/Prefabs/UI/Menus/MenuCanvas.prefab
@@ -4009,6 +4009,7 @@ RectTransform:
   - {fileID: 1550027280395465296}
   - {fileID: 7840388018622271612}
   - {fileID: 4657161535630824153}
+  - {fileID: 5436099173588554093}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -7048,7 +7049,7 @@ PrefabInstance:
       objectReference: {fileID: 8128258131871060397}
     - target: {fileID: 466533435504570254, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 466533435504570254, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
@@ -7132,35 +7133,67 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 498079454081798691, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 498079454081798691, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 498079454081798691, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 600
       objectReference: {fileID: 0}
     - target: {fileID: 498079454081798691, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 125
+      value: 98.75
       objectReference: {fileID: 0}
     - target: {fileID: 498079454081798691, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 498079454081798691, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -537.5
+      value: -485.625
       objectReference: {fileID: 0}
     - target: {fileID: 1140213559555388707, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_Padding.m_Top
       value: 65
       objectReference: {fileID: 0}
     - target: {fileID: 1140213559555388707, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_Padding.m_Left
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140213559555388707, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_Padding.m_Right
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140213559555388707, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_Padding.m_Bottom
       value: 65
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419964769890973388, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 8212606352112969578}
+    - target: {fileID: 1419964769890973388, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 8212606352112969578}
+    - target: {fileID: 1419964769890973388, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 8212606352112969578}
+    - target: {fileID: 1419964769890973388, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419964769890973388, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419964769890973388, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 1656343962051143921, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchorMax.y
@@ -7172,11 +7205,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1656343962051143921, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 500
+      value: 600
       objectReference: {fileID: 0}
     - target: {fileID: 1656343962051143921, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 125
+      value: 98.75
       objectReference: {fileID: 0}
     - target: {fileID: 1656343962051143921, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -7184,7 +7217,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1656343962051143921, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -12.5
+      value: -361.875
       objectReference: {fileID: 0}
     - target: {fileID: 3041369311159645949, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_Name
@@ -7300,11 +7333,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3527170424392536363, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3527170424392536363, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3527170424392536363, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_SizeDelta.x
@@ -7312,11 +7345,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3527170424392536363, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 960
       objectReference: {fileID: 0}
     - target: {fileID: 3527170424392536363, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -217.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3583328391671930842, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: mainMenuController
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 3647716526354686626, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_text
+      value: Friends Only
+      objectReference: {fileID: 0}
+    - target: {fileID: 3647716526354686626, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_fontSize
+      value: 70
       objectReference: {fileID: 0}
     - target: {fileID: 4761102662359094921, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -7388,27 +7433,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4792437529069775652, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4792437529069775652, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4792437529069775652, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 600
       objectReference: {fileID: 0}
     - target: {fileID: 4792437529069775652, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 125
+      value: 98.75
       objectReference: {fileID: 0}
     - target: {fileID: 4792437529069775652, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 4792437529069775652, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -362.5
+      value: -114.375
       objectReference: {fileID: 0}
     - target: {fileID: 5006318415180358299, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchorMax.y
@@ -7512,19 +7557,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6090067780547738498, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6090067780547738498, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6090067780547738498, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 960
       objectReference: {fileID: 0}
     - target: {fileID: 6090067780547738498, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -757.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6291501560300597862, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6291501560300597862, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6291501560300597862, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 6291501560300597862, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 98.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 6291501560300597862, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 6291501560300597862, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -238.125
       objectReference: {fileID: 0}
     - target: {fileID: 7055458770637592391, guid: 58e54f7d80aca2645ab598618dffc039, type: 3}
       propertyPath: m_Pivot.x
@@ -10123,6 +10192,564 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &3920102767319073597
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 712943427912787205}
+    m_Modifications:
+    - target: {fileID: 585662210370404010, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_Name
+      value: GamemodeQueueMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 585662210370404010, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 885509857465099464, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 885509857465099464, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 885509857465099464, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1920
+      objectReference: {fileID: 0}
+    - target: {fileID: 885509857465099464, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 408
+      objectReference: {fileID: 0}
+    - target: {fileID: 885509857465099464, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 960
+      objectReference: {fileID: 0}
+    - target: {fileID: 885509857465099464, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -204
+      objectReference: {fileID: 0}
+    - target: {fileID: 911361713361987726, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 911361713361987726, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 911361713361987726, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[5].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 911361713361987726, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[5].m_MethodName
+      value: FetchQueueLobbyInfo
+      objectReference: {fileID: 0}
+    - target: {fileID: 911361713361987726, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 4026824962317560842}
+    - target: {fileID: 911361713361987726, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2878829664369250595}
+    - target: {fileID: 1545692976137449455, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 1545692976137449455, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 22957778514632366}
+    - target: {fileID: 1545692976137449455, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 5909153864593058126}
+    - target: {fileID: 1545692976137449455, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 7845412700522379583}
+    - target: {fileID: 1545692976137449455, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 1777093362707272647}
+    - target: {fileID: 2272621449971197888, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_Navigation.m_SelectOnUp
+      value: 
+      objectReference: {fileID: 1065839163246693974}
+    - target: {fileID: 2272621449971197888, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 2272621449971197888, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 2272621449971197888, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 4181838527916903602}
+    - target: {fileID: 2272621449971197888, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 4772157052296254996}
+    - target: {fileID: 3198395762346560970, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 3198395762346560970, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 3198395762346560970, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[5].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 3198395762346560970, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[5].m_MethodName
+      value: FetchQueueLobbyInfo
+      objectReference: {fileID: 0}
+    - target: {fileID: 3198395762346560970, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 4026824962317560842}
+    - target: {fileID: 3198395762346560970, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2878829664369250595}
+    - target: {fileID: 3407030578384746114, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3407030578384746114, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3407030578384746114, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 950
+      objectReference: {fileID: 0}
+    - target: {fileID: 3407030578384746114, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 672
+      objectReference: {fileID: 0}
+    - target: {fileID: 3407030578384746114, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 1385
+      objectReference: {fileID: 0}
+    - target: {fileID: 3407030578384746114, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -336
+      objectReference: {fileID: 0}
+    - target: {fileID: 3508542411741965005, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3508542411741965005, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3508542411741965005, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 830
+      objectReference: {fileID: 0}
+    - target: {fileID: 3508542411741965005, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 672
+      objectReference: {fileID: 0}
+    - target: {fileID: 3508542411741965005, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 475
+      objectReference: {fileID: 0}
+    - target: {fileID: 3508542411741965005, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -336
+      objectReference: {fileID: 0}
+    - target: {fileID: 4084095950531890539, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 3021626833312621821}
+    - target: {fileID: 4084095950531890539, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 4084095950531890539, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 4084095950531890539, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[5].m_Target
+      value: 
+      objectReference: {fileID: 1098348358083011975}
+    - target: {fileID: 4084095950531890539, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[5].m_MethodName
+      value: FetchQueueLobbyInfo
+      objectReference: {fileID: 0}
+    - target: {fileID: 4084095950531890539, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 4026824962317560842}
+    - target: {fileID: 4084095950531890539, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2878829664369250595}
+    - target: {fileID: 4648640760686477070, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4648640760686477070, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4648640760686477070, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 730
+      objectReference: {fileID: 0}
+    - target: {fileID: 4648640760686477070, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 91
+      objectReference: {fileID: 0}
+    - target: {fileID: 4648640760686477070, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 425
+      objectReference: {fileID: 0}
+    - target: {fileID: 4648640760686477070, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -85.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5214767720284220452, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5214767720284220452, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5214767720284220452, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 730
+      objectReference: {fileID: 0}
+    - target: {fileID: 5214767720284220452, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 116.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5214767720284220452, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 415
+      objectReference: {fileID: 0}
+    - target: {fileID: 5214767720284220452, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -265.125
+      objectReference: {fileID: 0}
+    - target: {fileID: 5875010207219641157, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5875010207219641157, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5875010207219641157, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 709.9529
+      objectReference: {fileID: 0}
+    - target: {fileID: 5875010207219641157, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 94.10811
+      objectReference: {fileID: 0}
+    - target: {fileID: 5875010207219641157, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 404.97644
+      objectReference: {fileID: 0}
+    - target: {fileID: 5875010207219641157, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -469.3784
+      objectReference: {fileID: 0}
+    - target: {fileID: 6589509595454284650, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6589509595454284650, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6589509595454284650, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 730
+      objectReference: {fileID: 0}
+    - target: {fileID: 6589509595454284650, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 116.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 6589509595454284650, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 415
+      objectReference: {fileID: 0}
+    - target: {fileID: 6589509595454284650, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -548.625
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537232724053707104, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537232724053707104, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537232724053707104, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 730
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537232724053707104, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 116.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537232724053707104, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 415
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537232724053707104, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -123.375
+      objectReference: {fileID: 0}
+    - target: {fileID: 7610946461325094282, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7610946461325094282, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7610946461325094282, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 730
+      objectReference: {fileID: 0}
+    - target: {fileID: 7610946461325094282, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 301
+      objectReference: {fileID: 0}
+    - target: {fileID: 7610946461325094282, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 425
+      objectReference: {fileID: 0}
+    - target: {fileID: 7610946461325094282, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -281.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7637475039749655287, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7637475039749655287, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7637475039749655287, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 850
+      objectReference: {fileID: 0}
+    - target: {fileID: 7637475039749655287, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 472
+      objectReference: {fileID: 0}
+    - target: {fileID: 7637475039749655287, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 475
+      objectReference: {fileID: 0}
+    - target: {fileID: 7637475039749655287, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -336
+      objectReference: {fileID: 0}
+    - target: {fileID: 8778916719351711557, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8778916719351711557, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8778916719351711557, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1920
+      objectReference: {fileID: 0}
+    - target: {fileID: 8778916719351711557, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 672
+      objectReference: {fileID: 0}
+    - target: {fileID: 8778916719351711557, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 960
+      objectReference: {fileID: 0}
+    - target: {fileID: 8778916719351711557, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -744
+      objectReference: {fileID: 0}
+    - target: {fileID: 8959562477183650241, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8959562477183650241, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8959562477183650241, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 730
+      objectReference: {fileID: 0}
+    - target: {fileID: 8959562477183650241, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 116.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 8959562477183650241, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 415
+      objectReference: {fileID: 0}
+    - target: {fileID: 8959562477183650241, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -406.875
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7078550011999289059, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 585662210370404010, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1371734231462909598}
+  m_SourcePrefab: {fileID: 100100000, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+--- !u!114 &1065839163246693974 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4084095950531890539, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+  m_PrefabInstance: {fileID: 3920102767319073597}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3021626833312621821 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2272621449971197888, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+  m_PrefabInstance: {fileID: 3920102767319073597}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &4487749204754251159 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 585662210370404010, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+  m_PrefabInstance: {fileID: 3920102767319073597}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1371734231462909598
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4487749204754251159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 93be8166da43256488b46d323450b119, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mainMenuController: {fileID: 1098348358083011975}
+--- !u!224 &5436099173588554093 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 9013928090021007952, guid: d7e3975743f945e40938357aa3b5b1e2, type: 3}
+  m_PrefabInstance: {fileID: 3920102767319073597}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4696646346936247206
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Scoreboards.prefab
+++ b/Assets/Prefabs/UI/Scoreboards.prefab
@@ -85,6 +85,7 @@ MonoBehaviour:
   - IN 512 SECTORS
   - IN A BLOCK OF MEMORY OR ALIVE
   - FOR POLLING IN THE RIGHT HALF PLANE
+  - FOR RADIOACTIVE MIRACLE SORTING
   nextCrimeSound: {fileID: 11400000, guid: b85c2d27bf39bda4787e149b19385438, type: 2}
   newCrimeDelay: 1
   matchProgressDelay: 5

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 785370674}
-  m_IndirectSpecularColor: {r: 0.062419992, g: 0.21929295, b: 0.4948398, a: 1}
+  m_IndirectSpecularColor: {r: 0.062501624, g: 0.21940455, b: 0.49506256, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -765,6 +765,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: e82874ba34dffc64f840e8d7656aac9b, type: 3}
   m_PrefabInstance: {fileID: 1479396539}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &422359687 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1875182663465979639, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+  m_PrefabInstance: {fileID: 8419046673555529006}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &468501525
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1501,6 +1512,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 77e98a4fc4eb9834ba667e6a821870f8, type: 3}
+--- !u!114 &1262346684 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4448356365674713062, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+  m_PrefabInstance: {fileID: 8419046673555529006}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1306213762
 GameObject:
   m_ObjectHideFlags: 1
@@ -1533,6 +1555,11 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1315555705 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1871791169182432390, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+  m_PrefabInstance: {fileID: 8419046673555529006}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1372750352 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2946718800728160598, guid: 025aeacc91556754b8e3da18f5bd92bc, type: 3}
@@ -2562,6 +2589,42 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 254867710215572611, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 8419046673555529007}
+    - target: {fileID: 254867710215572611, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 8419046673555529007}
+    - target: {fileID: 254867710215572611, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 8419046673555529007}
+    - target: {fileID: 254867710215572611, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SwitchToMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 254867710215572611, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: SelectControl
+      objectReference: {fileID: 0}
+    - target: {fileID: 254867710215572611, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: HostFriendsOnlyLobby
+      objectReference: {fileID: 0}
+    - target: {fileID: 254867710215572611, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
+      value: MainMenuController, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 254867710215572611, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 1315555705}
+    - target: {fileID: 254867710215572611, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 1262346684}
     - target: {fileID: 320833117037194416, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2846,6 +2909,22 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
       value: PlayAnimations
       objectReference: {fileID: 0}
+    - target: {fileID: 1065839163246693974, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 378774849}
+    - target: {fileID: 1065839163246693974, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[3].m_Target
+      value: 
+      objectReference: {fileID: 1372750352}
+    - target: {fileID: 1065839163246693974, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: MoveToPlayerSelect
+      objectReference: {fileID: 0}
+    - target: {fileID: 1065839163246693974, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
+      value: PlayAnimations
+      objectReference: {fileID: 0}
     - target: {fileID: 1088328476082206502, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -3035,6 +3114,14 @@ PrefabInstance:
       value: MainMenuController, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 1604608621933614529, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 8419046673555529009}
+    - target: {fileID: 1604608621933614529, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 422359687}
+    - target: {fileID: 1604608621933614529, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
@@ -3137,6 +3224,22 @@ PrefabInstance:
     - target: {fileID: 1871791169182432390, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1875182663465979639, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 378774849}
+    - target: {fileID: 1875182663465979639, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[3].m_Target
+      value: 
+      objectReference: {fileID: 1372750352}
+    - target: {fileID: 1875182663465979639, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: MoveToPlayerSelect
+      objectReference: {fileID: 0}
+    - target: {fileID: 1875182663465979639, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
+      value: PlayAnimations
       objectReference: {fileID: 0}
     - target: {fileID: 1876406567940449895, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
@@ -3440,7 +3543,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3852112221443098392, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_Name
-      value: Private
+      value: Local
       objectReference: {fileID: 0}
     - target: {fileID: 3977087451557504359, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
@@ -3501,6 +3604,22 @@ PrefabInstance:
     - target: {fileID: 4181838527916903602, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4234173188529023923, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 378774849}
+    - target: {fileID: 4234173188529023923, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[3].m_Target
+      value: 
+      objectReference: {fileID: 1372750352}
+    - target: {fileID: 4234173188529023923, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: MoveToPlayerSelect
+      objectReference: {fileID: 0}
+    - target: {fileID: 4234173188529023923, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
+      value: PlayAnimations
       objectReference: {fileID: 0}
     - target: {fileID: 4239541196560821539, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
       propertyPath: m_AnchorMax.y
@@ -4766,3 +4885,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4b5c1573441f904429ca01beb1ebfdd1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &8419046673555529009 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4487749204754251159, guid: cbf30f348674af6ecb2ba42ec2aacaf6, type: 3}
+  m_PrefabInstance: {fileID: 8419046673555529006}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scripts/UI/Gamemode/GamemodeSelectMenu.cs
+++ b/Assets/Scripts/UI/Gamemode/GamemodeSelectMenu.cs
@@ -20,6 +20,12 @@ public class GamemodeSelectMenu : MonoBehaviour
         description.text = gamemode.Description;
     }
 
+    public void ClearText()
+    {
+        title.text = "";
+        description.text = "";
+    }
+
     public void SetGamemode(Ruleset gamemode)
     {
         MatchRules.Singleton.SetCreatedRuleset(gamemode);

--- a/Assets/Scripts/UI/LobbySelect.cs
+++ b/Assets/Scripts/UI/LobbySelect.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+public class LobbySelect : MonoBehaviour
+{
+    [SerializeField]
+    private Button queueButton;
+    [SerializeField]
+    private Button friendsButton;
+    [SerializeField]
+    private Selectable localButton;
+    [SerializeField]
+    private TMP_Text title;
+    [SerializeField]
+    private TMP_Text description;
+    [SerializeField]
+    private MainMenuController mainMenuController;
+
+    private void OnEnable()
+    {
+        var isOnline = SteamManager.IsSteamActive;
+
+        if (!isOnline)
+            StartCoroutine(WaitAndSelectButton());
+        SetOnlineButtonStates(isOnline);
+    }
+    public void SetTitle(string text)
+    {
+        title.text = text;
+    }
+
+    public void SetDescription(string text)
+    {
+        description.text = text;
+    }
+
+    private void SetOnlineButtonStates(bool enabled)
+    {
+        queueButton.enabled = enabled;
+        friendsButton.enabled = enabled;
+    }
+
+    private IEnumerator WaitAndSelectButton()
+    {
+        yield return null;
+        mainMenuController.SelectControl(localButton);
+    }
+}

--- a/Assets/Scripts/UI/LobbySelect.cs.meta
+++ b/Assets/Scripts/UI/LobbySelect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c86e20c1de66f6549b9480a0665290eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/MainMenu/MainMenuController.cs
@@ -360,8 +360,6 @@ public class MainMenuController : MonoBehaviour
 
     public void FetchLobbyInfo()
     {
-        if (!SteamManager.IsSteamActive)
-            return;
         SteamManager.Singleton.FetchLobbyInfo();
     }
 

--- a/Assets/Scripts/Utils/SteamManager.cs
+++ b/Assets/Scripts/Utils/SteamManager.cs
@@ -320,6 +320,9 @@ public class SteamManager : MonoBehaviour
 
     public void FetchLobbyInfo()
     {
+        if (!IsSteamActive)
+            return;
+
         FetchFriendLobbyInfo();
         // Filter lobbies of same game version
         SteamMatchmaking.AddRequestLobbyListStringFilter(Lobby.GameVersionProperty,
@@ -334,6 +337,9 @@ public class SteamManager : MonoBehaviour
 
     public void FetchQueueLobbyInfo()
     {
+        if (!IsSteamActive)
+            return;
+
         // Filter lobbies of same game version
         SteamMatchmaking.AddRequestLobbyListStringFilter(Lobby.GameVersionProperty,
                                                             Application.version,


### PR DESCRIPTION
- Added description box for lobby modes
- Made Queue and Friends Only buttons unselectable if users don't have access to Steam
- Made all description boxes display blank text when selected

Also reverted a wrong checkout in rebase conflict from #747, ooops.