### PR TITLE
Fix Collider::ClosestPoint() warnings

### DIFF
--- a/Assets/Scripts/Augment/BulletModifiers/DecalModifier.cs
+++ b/Assets/Scripts/Augment/BulletModifiers/DecalModifier.cs
@@ -1,3 +1,4 @@
+using MiscExtensions;
 using UnityEngine;
 using UnityEngine.Rendering.Universal;
 
@@ -21,7 +22,7 @@ public class DecalModifier : MonoBehaviour, ProjectileModifier
     [Range(0f, 1f)][SerializeField] private float stickToNormalFraction = 0;
 
     [Range(0f, 180f)][SerializeField] private float angleVariation = 180f;
-    
+
     private const int allGunsAndPlayersMask = (1 << 8) | (1 << 9) | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 13) | (1 << 14) | (1 << 15);
 
     private void Awake()
@@ -71,7 +72,7 @@ public class DecalModifier : MonoBehaviour, ProjectileModifier
 
         // Place the decal some distance away from the target so that it is more likely to be projected onto a surface
         var depthOffset = decal.size.z * depthOffsetFraction;
-        spawnedDecal.transform.position = target.collider.ClosestPoint(state.position) - state.direction * depthOffset;
+        spawnedDecal.transform.position = target.ClosestPoint(state.position) - state.direction * depthOffset;
         spawnedDecal.transform.rotation = DetermineRotation(target.collider, state);
         spawnedDecal.transform.parent = target.collider.transform;
 

--- a/Assets/Scripts/Augment/BulletModifiers/StickyProjectileModifier.cs
+++ b/Assets/Scripts/Augment/BulletModifiers/StickyProjectileModifier.cs
@@ -1,6 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
+using MiscExtensions;
 using TransformExtensions;
 
 /// <summary>
@@ -47,7 +46,8 @@ public class StickyProjectileModifier : MonoBehaviour, ProjectileModifier
     {
         if (!(affectedLayers == (affectedLayers | (1 << hit.collider.gameObject.layer))))
             return;
-        var stuck = Instantiate(stuckObject, hit.collider.ClosestPoint(state.position), state.rotation);
+
+        var stuck = Instantiate(stuckObject, hit.ClosestPoint(state.position), state.rotation);
         stuck.transform.ParentUnscaled(hit.collider.transform);
         if (stuck.TryGetComponent<ContinuousDamage>(out var continuousDamage))
             continuousDamage.source = source;

--- a/Assets/Scripts/Extensions/MiscExtensions.cs
+++ b/Assets/Scripts/Extensions/MiscExtensions.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace MiscExtensions
+{
+    public static class MiscExtensions
+    {
+        public static Vector3 ClosestPoint(this RaycastHit hit, Vector3 position) =>
+            hit.collider is BoxCollider or SphereCollider or CapsuleCollider or MeshCollider
+            ? hit.collider.ClosestPoint(position)
+            : hit.point;
+    }
+}

--- a/Assets/Scripts/Extensions/MiscExtensions.cs.meta
+++ b/Assets/Scripts/Extensions/MiscExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09f39eefcef24075cae6bf80a5d165b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
ClosestPoint() can only be used on some colliders, this should avoid most cases of that warning