### PR TITLE
Fix overlay stencil for ONLY damagepopup instead of every stencil font

### DIFF
--- a/Assets/Prefabs/UI/DamagePopup.prefab
+++ b/Assets/Prefabs/UI/DamagePopup.prefab
@@ -143,8 +143,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 20
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: d9a852cc525d17841bddd69dcb8cc48b, type: 2}
-  m_sharedMaterial: {fileID: -1782873873408761557, guid: d9a852cc525d17841bddd69dcb8cc48b, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 72b62df8bbd2d494eb26e2df684260be, type: 2}
+  m_sharedMaterial: {fileID: -1782873873408761557, guid: 72b62df8bbd2d494eb26e2df684260be, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Assets/TextMesh Pro/Resources/Fonts & Materials/STENCIL(Overlay).asset
+++ b/Assets/TextMesh Pro/Resources/Fonts & Materials/STENCIL(Overlay).asset
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: STENCIL SDF Material
-  m_Shader: {fileID: 4800000, guid: 68e6db2ebdc24f95958faec2be5558d6, type: 3}
+  m_Shader: {fileID: 4800000, guid: dd89cf5b9246416f84610a006f916af7, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
@@ -166,11 +166,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
-  m_Name: STENCIL
+  m_Name: STENCIL(Overlay)
   m_EditorClassIdentifier: 
-  hashCode: 1769005162
+  hashCode: 27238353
   material: {fileID: -1782873873408761557}
-  materialHashCode: 733184138
+  materialHashCode: -1767411887
   m_Version: 1.1.0
   m_SourceFontFileGUID: 9fbffe50f2deb70b18ac622eba076643
   m_SourceFontFile_EditorRef: {fileID: 12800000, guid: 9fbffe50f2deb70b18ac622eba076643, type: 3}

--- a/Assets/TextMesh Pro/Resources/Fonts & Materials/STENCIL(Overlay).asset.meta
+++ b/Assets/TextMesh Pro/Resources/Fonts & Materials/STENCIL(Overlay).asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 72b62df8bbd2d494eb26e2df684260be
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixed issue where every instance of the stencil font would be overlayed over geometry and not just the damage popup

Now we have a seperate font for overlay, which we can possible use later for stopping transparent edge shader bleedthrough on UI