### PR TITLE
Refactor player initialization

### DIFF
--- a/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
+++ b/Assets/Scripts/Control&Input/Peer2PeerTransport.cs
@@ -27,6 +27,14 @@ public struct PlayerDetails
     public string body;
     public string barrel;
     public string extension;
+
+    public string PlayerNameWithIndex()
+    {
+        var mySteamID = steamID;
+        if (Peer2PeerTransport.PlayerDetails.Count(p => p.steamID == mySteamID) > 1)
+            return $"{name} {localInputID + 1}";
+        return name;
+    }
 }
 
 public struct PlayerConnectedMessage : NetworkMessage
@@ -134,8 +142,6 @@ public class Peer2PeerTransport : NetworkManager
     private const int BiddingPlayerPrefabIndexOffset = 1;
     private const int AIFPSPlayerPrefabIndex = 2;
     private const int TrainingPlayerPrefabIndex = 4;
-
-    private const int NetworkPlayerLayer = 3;
 
     private PlayerFactory playerFactory;
     private static Transform[] spawnPoints;
@@ -701,8 +707,8 @@ public class Peer2PeerTransport : NetworkManager
 
     #endregion
 
-    #region Spawn FPS players
 
+    #region Spawn players
 
     private void SpawnPlayer(NetworkConnectionToClient connection, SpawnPlayerMessage message, int prefabIndexOffset = 0)
     {
@@ -754,24 +760,20 @@ public class Peer2PeerTransport : NetworkManager
 
     private void InitializeFPSPlayer(InitializePlayerMessage message)
     {
-        StartCoroutine(WaitAndInitializeFPSPlayer(message));
+        StartCoroutine(WaitAndInitializePlayer(message, false));
     }
 
-    // TODO move this somewhere else?
-    public static string PlayerNameWithIndex(PlayerDetails playerDetails)
+    private void OnSpawnBiddingPlayer(NetworkConnectionToClient connection, SpawnPlayerMessage message)
     {
-        var playerName = playerDetails.name;
-        if (players.Values.Count(p => p.steamID == playerDetails.steamID) > 1)
-            playerName = $"{playerName} {playerDetails.localInputID + 1}";
-        return playerName;
+        SpawnPlayer(connection, message, BiddingPlayerPrefabIndexOffset);
     }
 
-    private void UpdateIdentityFromDetails(PlayerIdentity identity, PlayerDetails playerDetails)
+    private void InitializeBiddingPlayer(InitializePlayerMessage message)
     {
-        identity.UpdateFromDetails(playerDetails, PlayerNameWithIndex(playerDetails));
+        StartCoroutine(WaitAndInitializePlayer(message, true));
     }
 
-    private IEnumerator WaitAndInitializeFPSPlayer(InitializePlayerMessage message)
+    private IEnumerator WaitAndInitializePlayer(InitializePlayerMessage message, bool isBidding = false)
     {
         // Wait until player object is spawned
         PlayerManager player = null;
@@ -794,205 +796,7 @@ public class Peer2PeerTransport : NetworkManager
             yield break;
         }
 
-        var playerManager = player.GetComponent<PlayerManager>();
-
-        player.transform.position = message.position;
-        player.transform.rotation = message.rotation;
-
-        var cameraOffset = player.transform.Find("CameraOffset");
-        playerManager.GetComponent<AmmoBoxCollector>().enabled = true;
-
-        if (playerDetails.type is PlayerType.Local)
-        {
-            Debug.Log($"Spawning local player {playerDetails.id}");
-            var input = PlayerInputManagerController.Singleton.LocalPlayerInputs[playerDetails.localInputID];
-
-            // Reset camera transform (it may have been kerfluffled by the spectator cam thingy)
-            input.transform.localPosition = Vector3.zero;
-            input.transform.localRotation = Quaternion.identity;
-            input.PlayerCamera.transform.localRotation = Quaternion.identity;
-            input.PlayerCamera.transform.localPosition = Vector3.zero;
-
-            // Make playerInput child of player it's attached to
-            input.transform.parent = player.transform;
-            // Set received playerInput (and most importantly its camera) at an offset from player's position
-            input.transform.localPosition = cameraOffset.localPosition;
-            input.transform.rotation = player.transform.rotation;
-
-            // Enable Camera
-            input.PlayerCamera.enabled = true;
-            input.PlayerCamera.orthographic = false;
-
-            playerManager.HUDController.gameObject.SetActive(true);
-            var movement = player.GetComponent<PlayerMovement>();
-
-            // The identity sits on the input in this case, so edit that
-            var identity = input.GetComponent<PlayerIdentity>();
-            UpdateIdentityFromDetails(identity, playerDetails);
-
-            // Update player's movement script with which playerInput it should attach listeners to
-            playerManager.SetPlayerInput(input);
-            var gunHolder = input.transform.GetChild(0);
-            playerManager.SetGun(gunHolder);
-
-            // Set unique layer for player
-            playerManager.SetLayer(input.playerInput.playerIndex);
-            movement.SetInitialRotation(message.rotation.eulerAngles.y * Mathf.Deg2Rad);
-
-            if (GunFactory.TryGetGunAchievement(playerManager.identity.Body, playerManager.identity.Barrel,
-                    playerManager.identity.Extension, out var achievement))
-                SteamManager.Singleton.UnlockAchievement(achievement);
-        }
-        else if (playerDetails.type is PlayerType.AI && NetworkServer.active)
-        {
-            Debug.Log($"Spawning AI player {playerDetails.id}");
-            AIManager manager = player.GetComponent<AIManager>();
-            manager.SetLayer(NetworkPlayerLayer);
-            UpdateIdentityFromDetails(playerManager.identity, playerDetails);
-            manager.SetIdentity(playerManager.identity);
-            manager.GetComponent<AIMovement>().SetInitialRotation(message.rotation.eulerAngles.y * Mathf.Deg2Rad);
-        }
-        else
-        {
-            Debug.Log($"Spawning network player {playerDetails.id}");
-
-            UpdateIdentityFromDetails(playerManager.identity, playerDetails);
-
-            // TODO do some other version of disabling HUD completely
-            Destroy(playerManager.HUDController);
-
-            // Disable physics
-            playerManager.GetComponent<Rigidbody>().isKinematic = true;
-
-            // Create display gun structure
-            var gunHolderParent = new GameObject("DisplayGunParent").transform;
-            gunHolderParent.parent = player.transform;
-            gunHolderParent.position = cameraOffset.position;
-            gunHolderParent.rotation = player.transform.rotation;
-            var gunHolder = new GameObject("DisplayGunHolder").transform;
-            gunHolder.parent = gunHolderParent.transform;
-            gunHolder.localPosition = Vector3.zero;
-            gunHolder.localRotation = Quaternion.identity;
-            playerManager.SetLayer(NetworkPlayerLayer);
-            // Can't initialize quite like the AIs because of where the GunController network behaviour is located :(
-            playerManager.SetGun(gunHolder);
-        }
-
-        playerManager.ApplyIdentity();
-
-        // This ensures that behaviours on the gun have identities.
-        // SHOULD be safe to initialize them here as this is at roughly the same point on all clients
-        player.GetComponent<NetworkIdentity>().InitializeNetworkBehaviours();
-
-        if (MatchController.Singleton)
-        {
-            MatchController.Singleton.RegisterPlayer(playerManager);
-        }
-
-        playerInstances[player.id] = player;
-    }
-
-    #endregion
-
-    #region Bidding spawning
-
-    private void OnSpawnBiddingPlayer(NetworkConnectionToClient connection, SpawnPlayerMessage message)
-    {
-        SpawnPlayer(connection, message, BiddingPlayerPrefabIndexOffset);
-    }
-
-    private void InitializeBiddingPlayer(InitializePlayerMessage message)
-    {
-        StartCoroutine(WaitAndInitializeBiddingPlayer(message));
-    }
-
-    private IEnumerator WaitAndInitializeBiddingPlayer(InitializePlayerMessage message)
-    {
-        // Wait until players must've been spawned
-        PlayerManager player = null;
-        while (player == null)
-        {
-            player = FindObjectsOfType<PlayerManager>()
-               .FirstOrDefault(p => p.id == message.id);
-            yield return null;
-        }
-
-        if (!player)
-        {
-            Debug.LogError($"Could not find player object for id {message.id}");
-            yield break;
-        }
-
-        if (!players.TryGetValue(message.id, out var playerDetails))
-        {
-            Debug.LogError($"Could not find player details for id {message.id}");
-            yield break;
-        }
-
-        var playerManager = player.GetComponent<PlayerManager>();
-
-        player.transform.position = message.position;
-        player.transform.rotation = message.rotation;
-
-        var cameraOffset = player.transform.Find("CameraOffset");
-        playerManager.GetComponent<AmmoBoxCollector>().enabled = true;
-
-        if (playerDetails.type is PlayerType.Local)
-        {
-            Debug.Log($"Spawning local player {playerDetails.id}");
-            var input = PlayerInputManagerController.Singleton.LocalPlayerInputs[playerDetails.localInputID];
-
-            // Reset camera transform (ensuring we don't mess up in weapon building)
-            input.transform.localPosition = Vector3.zero;
-            input.transform.localRotation = Quaternion.identity;
-            input.PlayerCamera.transform.localRotation = Quaternion.identity;
-            input.PlayerCamera.transform.localPosition = Vector3.zero;
-
-            // Make playerInput child of player it's attached to
-            input.transform.parent = player.transform;
-            // Set received playerInput (and most importantly its camera) at an offset from player's position
-            input.transform.localPosition = cameraOffset.localPosition;
-            input.transform.rotation = player.transform.rotation;
-
-            // Disable Camera
-            input.PlayerCamera.enabled = false;
-
-            // Update player's movement script with which playerInput it should attach listeners to
-            playerManager.SetPlayerInput(input);
-            player.GetComponent<HealthController>().enabled = false;
-
-            // The identity sits on the input in this case, so edit that
-            var identity = input.GetComponent<PlayerIdentity>();
-            UpdateIdentityFromDetails(identity, playerDetails);
-        }
-        else if (playerDetails.type is PlayerType.AI && NetworkServer.active)
-        {
-            Debug.Log($"Spawning AI player {playerDetails.id}");
-            AIManager manager = player.GetComponent<AIManager>();
-            manager.SetLayer(NetworkPlayerLayer);
-            UpdateIdentityFromDetails(playerManager.identity, playerDetails);
-            manager.SetIdentity(manager.identity);
-        }
-        else
-        {
-            Debug.Log($"Spawning network player {playerDetails.id}");
-
-            UpdateIdentityFromDetails(playerManager.identity, playerDetails);
-
-            // Disable physics
-            playerManager.GetComponent<Rigidbody>().isKinematic = true;
-        }
-
-        playerManager.ApplyIdentity();
-
-        // This ensures that behaviours on the gun have identities.
-        // SHOULD be safe to initialize them here as this is at roughly the same point on all clients
-        player.GetComponent<NetworkIdentity>().InitializeNetworkBehaviours();
-
-        if (MatchController.Singleton)
-        {
-            MatchController.Singleton.RegisterPlayer(playerManager);
-        }
+        PlayerFactory.InitializePlayer(message, player, playerDetails, isBidding);
 
         playerInstances[player.id] = player;
     }

--- a/Assets/Scripts/Gamestate/PlayerFactory.cs
+++ b/Assets/Scripts/Gamestate/PlayerFactory.cs
@@ -3,6 +3,7 @@ using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using UnityEngine;
 using CollectionExtensions;
+using Mirror;
 
 public class PlayerFactory : MonoBehaviour
 {
@@ -10,8 +11,11 @@ public class PlayerFactory : MonoBehaviour
     private Transform[] spawnPoints;
     [SerializeField]
     private GameObject playerSelectItemPrefab;
+
     private float spawnInterval = 0f;
     private PlayerInputManagerController playerInputManagerController;
+
+    private const int NetworkPlayerLayer = 3;
 
     private void Awake()
     {
@@ -29,14 +33,15 @@ public class PlayerFactory : MonoBehaviour
         playerInputManagerController.PlayerInputManager.splitScreen = true;
     }
 
+    #region Weapon construction spawning
+
     public void InstantiatePlayerSelectItems()
     {
         playerInputManagerController.ChangeInputMaps("Menu");
         InstantiateInputsOnSpawnpoints(InstantiateItemSelectPlayer);
     }
 
-    // TODO remove this from its mortal coil, we don't really use PlayerFactory anymore :)
-    private List<PlayerManager> InstantiateInputsOnSpawnpoints(Func<InputManager, Transform, PlayerManager> instantiate, Func<int, Transform, AIManager> instantiateAI = null, int aiPlayerCount = 0)
+    private List<PlayerManager> InstantiateInputsOnSpawnpoints(Func<InputManager, Transform, PlayerManager> instantiate)
     {
         var shuffledSpawnPoints = spawnPoints.ShuffledCopy();
 
@@ -44,13 +49,6 @@ public class PlayerFactory : MonoBehaviour
         for (int i = 0; i < playerInputManagerController.LocalPlayerInputs.Count; i++)
         {
             playerList.Add(instantiate(playerInputManagerController.LocalPlayerInputs[i], shuffledSpawnPoints[i % spawnPoints.Length]));
-        }
-        for (int i = playerInputManagerController.LocalPlayerInputs.Count; i < playerInputManagerController.LocalPlayerInputs.Count + aiPlayerCount; i++)
-        {
-            var spawnPoint = shuffledSpawnPoints[i % spawnPoints.Length];
-            var aiPlayer = instantiateAI(i, spawnPoint);
-
-            playerList.Add(aiPlayer);
         }
         return playerList;
     }
@@ -70,4 +68,152 @@ public class PlayerFactory : MonoBehaviour
         StartCoroutine(player.GetComponent<ItemSelectMenu>().SpawnItems(inputManager));
         return null;
     }
+
+    #endregion
+
+
+    #region Initialization
+
+    public static void InitializePlayer(InitializePlayerMessage message, PlayerManager player, PlayerDetails playerDetails, bool isBidding = false)
+    {
+        player.GetComponent<AmmoBoxCollector>().enabled = true;
+
+        player.transform.position = message.position;
+        player.transform.rotation = message.rotation;
+
+        Debug.Log($"Spawning {playerDetails.type} player {playerDetails.id}");
+
+        if (isBidding)
+            InitializeBiddingPlayer(message, player, playerDetails);
+        else
+            InitializeFPSPlayer(message, player, playerDetails);
+
+        player.ApplyIdentity();
+
+        // This ensures that behaviours on the gun have identities.
+        // SHOULD be safe to initialize them here as this is at roughly the same point on all clients
+        player.GetComponent<NetworkIdentity>().InitializeNetworkBehaviours();
+
+        if (MatchController.Singleton)
+        {
+            MatchController.Singleton.RegisterPlayer(player);
+        }
+    }
+
+    private static void InitializeFPSPlayer(InitializePlayerMessage message, PlayerManager player, PlayerDetails playerDetails)
+    {
+        var cameraOffset = player.transform.Find("CameraOffset");
+        if (playerDetails.type is PlayerType.Local)
+        {
+            var input = SetupLocalPlayerInput(player, playerDetails);
+
+            // Enable Camera
+            input.PlayerCamera.enabled = true;
+            input.PlayerCamera.orthographic = false;
+
+            player.HUDController.gameObject.SetActive(true);
+            var movement = player.GetComponent<PlayerMovement>();
+
+            // Update player's movement script with which playerInput it should attach listeners to
+            var gunHolder = input.transform.GetChild(0);
+            player.SetGun(gunHolder);
+
+            // Set unique layer for player
+            player.SetLayer(input.playerInput.playerIndex);
+            movement.SetInitialRotation(message.rotation.eulerAngles.y * Mathf.Deg2Rad);
+
+            if (GunFactory.TryGetGunAchievement(player.identity.Body, player.identity.Barrel,
+                    player.identity.Extension, out var achievement))
+                SteamManager.Singleton.UnlockAchievement(achievement);
+        }
+        else if (playerDetails.type is PlayerType.AI && NetworkServer.active)
+        {
+            InitializeAIPlayer(message, player, playerDetails);
+        }
+        else
+        {
+            player.identity.UpdateFromDetails(playerDetails);
+
+            // TODO do some other version of disabling HUD completely
+            Destroy(player.HUDController);
+
+            // Disable physics
+            player.GetComponent<Rigidbody>().isKinematic = true;
+
+            // Create display gun structure
+            var gunHolderParent = new GameObject("DisplayGunParent").transform;
+            gunHolderParent.parent = player.transform;
+            gunHolderParent.position = cameraOffset.position;
+            gunHolderParent.rotation = player.transform.rotation;
+            var gunHolder = new GameObject("DisplayGunHolder").transform;
+            gunHolder.parent = gunHolderParent.transform;
+            gunHolder.localPosition = Vector3.zero;
+            gunHolder.localRotation = Quaternion.identity;
+            player.SetLayer(NetworkPlayerLayer);
+            // Can't initialize quite like the AIs because of where the GunController network behaviour is located :(
+            player.SetGun(gunHolder);
+        }
+    }
+
+    private static void InitializeBiddingPlayer(InitializePlayerMessage message, PlayerManager player, PlayerDetails playerDetails)
+    {
+        if (playerDetails.type is PlayerType.Local)
+        {
+            var input = SetupLocalPlayerInput(player, playerDetails);
+
+            // Disable camera
+            input.PlayerCamera.enabled = false;
+
+            // Disable health
+            player.GetComponent<HealthController>().enabled = false;
+        }
+        else if (playerDetails.type is PlayerType.AI && NetworkServer.active)
+        {
+            InitializeAIPlayer(message, player, playerDetails);
+        }
+        else
+        {
+            player.identity.UpdateFromDetails(playerDetails);
+
+            // Disable physics
+            player.GetComponent<Rigidbody>().isKinematic = true;
+        }
+    }
+
+    private static InputManager SetupLocalPlayerInput(PlayerManager player, PlayerDetails playerDetails)
+    {
+        var input = PlayerInputManagerController.Singleton.LocalPlayerInputs[playerDetails.localInputID];
+        var cameraOffset = player.transform.Find("CameraOffset");
+
+        // Reset camera transform (it may have been kerfluffled by the spectator cam thingy)
+        input.transform.localPosition = Vector3.zero;
+        input.transform.localRotation = Quaternion.identity;
+        input.PlayerCamera.transform.localRotation = Quaternion.identity;
+        input.PlayerCamera.transform.localPosition = Vector3.zero;
+
+        // Make playerInput child of player it's attached to
+        input.transform.parent = player.transform;
+        // Set received playerInput (and most importantly its camera) at an offset from player's position
+        input.transform.localPosition = cameraOffset.localPosition;
+        input.transform.rotation = player.transform.rotation;
+
+        // The identity sits on the input in this case, so edit that
+        var identity = input.GetComponent<PlayerIdentity>();
+        identity.UpdateFromDetails(playerDetails);
+
+        player.SetPlayerInput(input);
+
+        return input;
+    }
+
+    private static void InitializeAIPlayer(InitializePlayerMessage message, PlayerManager player, PlayerDetails playerDetails)
+    {
+        AIManager manager = player.GetComponent<AIManager>();
+        manager.SetLayer(NetworkPlayerLayer);
+        player.identity.UpdateFromDetails(playerDetails);
+        manager.SetIdentity(player.identity);
+        manager.GetComponent<AIMovement>().SetInitialRotation(message.rotation.eulerAngles.y * Mathf.Deg2Rad);
+    }
+
+    #endregion
 }

--- a/Assets/Scripts/Gamestate/PlayerIdentity.cs
+++ b/Assets/Scripts/Gamestate/PlayerIdentity.cs
@@ -199,11 +199,11 @@ public class PlayerIdentity : MonoBehaviour
         this.extension = extension;
     }
 
-    public void UpdateFromDetails(PlayerDetails playerDetails, string name)
+    public void UpdateFromDetails(PlayerDetails playerDetails)
     {
         id = playerDetails.id;
 
-        playerName = name;
+        playerName = playerDetails.PlayerNameWithIndex();
         color = playerDetails.color;
 
         Chips = playerDetails.chips;

--- a/Assets/Scripts/PlayerSelect/PlayerSelectManager.cs
+++ b/Assets/Scripts/PlayerSelect/PlayerSelectManager.cs
@@ -95,7 +95,7 @@ public class PlayerSelectManager : MonoBehaviour
         playerModels[index].GetComponentInChildren<SkinnedMeshRenderer>().material.color = player.color; // Set player model color
         playerModels[index].SetActive(true); // Show corresponding player model
         playerModels[index].transform.LookAt(new Vector3(playerSelectCam.transform.position.x, playerModels[index].transform.position.y, playerSelectCam.transform.position.z)); // Orient player model to look at camera
-        nameTags[index].text = Peer2PeerTransport.PlayerNameWithIndex(player);
+        nameTags[index].text = player.PlayerNameWithIndex();
         nameTags[index].enabled = true;
         joinText[index].enabled = false;
     }


### PR DESCRIPTION
Refactored to

1. Happen in PlayerFactory rather than the network manager
2. Avoid duplicate code
3. Perform identity update within the identity itself