### PR TITLE
Make start button appear only after (local) server has started

### DIFF
--- a/Assets/Scripts/UI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/MainMenu/MainMenuController.cs
@@ -296,10 +296,6 @@ public class MainMenuController : MonoBehaviour
         if (firstInputJoined == null)
             firstInputJoined = inputManager;
 
-        bool canPlay = playerInputs.Count > 1;
-        var colors = startButton.colors;
-        colors.normalColor = canPlay ? colors.highlightedColor : colors.disabledColor;
-        startButton.colors = colors;
         inputManager.onMovePerformed += PlayUISelectAudio;
         inputManager.onSelect += PlayChooseAudio;
 


### PR DESCRIPTION
This *should* close #787 

For the record: I spotted a potential issue in that the start button's state is set before it should be.
Don't know for sure that this fixes the issue though, as I'm unable to replicate it here -_-