### PR TITLE
Prevent ragdoll cam from starting during scoreboard anim

### DIFF
--- a/Assets/Scripts/Gamestate/MatchController.cs
+++ b/Assets/Scripts/Gamestate/MatchController.cs
@@ -57,6 +57,10 @@ public class MatchController : NetworkBehaviour
     private bool isRoundInProgress = false;
     public bool IsRoundInProgress => isRoundInProgress;
 
+    private bool isShowingScoreboards = false;
+    public bool IsShowingScoreboards => isShowingScoreboards;
+
+
     private void Awake()
     {
         #region Singleton boilerplate
@@ -213,6 +217,7 @@ public class MatchController : NetworkBehaviour
     {
         // Delay first so we can see who killed who
         yield return new WaitForSeconds(delayBeforeRoundResults);
+        isShowingScoreboards = true;
         // Scoreboard subscribes here
         onRoundEnd?.Invoke();
     }

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -228,9 +228,7 @@ public class PlayerManager : NetworkBehaviour
         if (inputManager)
         {
             var orbitCamera = GetComponent<OrbitCamera>();
-            orbitCamera.Camera = inputManager.PlayerCamera;
-            orbitCamera.InputManager = inputManager;
-            orbitCamera.Activate();
+            orbitCamera.Activate(inputManager);
         }
 
         // TODO: Make accurate hitbox forces for the different limbs of the player


### PR DESCRIPTION
Closes #793 

Also refactors so that inputmanager and camera can only be set by passing them to the Activate method. The previous iteration could result in invalid state.