### PR TITLE
Fix colors not showing in killfeed in builds

### DIFF
--- a/Assets/Scripts/Gamestate/PlayerIdentity.cs
+++ b/Assets/Scripts/Gamestate/PlayerIdentity.cs
@@ -214,9 +214,5 @@ public class PlayerIdentity : MonoBehaviour
 
     public override string ToString() => playerName;
 
-#if UNITY_EDITOR
     public string ToColorString() => $"<color=#{color.ToHexString()}>{playerName}</color>";
-#else
-    public string ToColorString() => playerName;
-#endif
 }


### PR DESCRIPTION
Forgot to remove editor-only macro once the color string thingy was used elsewhere >_<