### PR TITLE
Crosshair with modifiable radius and inverse colors

### DIFF
--- a/Assets/Prefabs/GunParts/BulletBarrel.prefab
+++ b/Assets/Prefabs/GunParts/BulletBarrel.prefab
@@ -662,9 +662,14 @@ MonoBehaviour:
     addition: 0
     multiplier: 0
     exponential: 2
+  - name: CrosshairRadius
+    addition: -0.8
+    multiplier: 0
+    exponential: 1
   outputs:
   - {fileID: 5765902433490691002}
   midpoint: {fileID: 5139843727155892186}
+  crossHairMode: 0
   attachmentPoints:
   - {fileID: 5765902433490691002}
   muzzleFlash: {fileID: 261841362781268065}

--- a/Assets/Prefabs/GunParts/CannonBarrel.prefab
+++ b/Assets/Prefabs/GunParts/CannonBarrel.prefab
@@ -256,12 +256,13 @@ MonoBehaviour:
     multiplier: 0
     exponential: 1
   - name: CrosshairRadius
-    addition: 0.8
+    addition: 1.2
     multiplier: 0
     exponential: 1
   outputs:
   - {fileID: 1160446427348008624}
   midpoint: {fileID: 6064389157985578044}
+  crossHairMode: 0
   attachmentPoints:
   - {fileID: 1160446427348008624}
   muzzleFlash: {fileID: 3336205849109724685}

--- a/Assets/Prefabs/GunParts/CannonBarrel.prefab
+++ b/Assets/Prefabs/GunParts/CannonBarrel.prefab
@@ -255,6 +255,10 @@ MonoBehaviour:
     addition: 0.3
     multiplier: 0
     exponential: 1
+  - name: CrosshairRadius
+    addition: 0.8
+    multiplier: 0
+    exponential: 1
   outputs:
   - {fileID: 1160446427348008624}
   midpoint: {fileID: 6064389157985578044}

--- a/Assets/Prefabs/GunParts/CoilBarrel.prefab
+++ b/Assets/Prefabs/GunParts/CoilBarrel.prefab
@@ -407,6 +407,10 @@ MonoBehaviour:
     addition: 0
     multiplier: 0
     exponential: 0
+  - name: CrosshairRadius
+    addition: 1.2
+    multiplier: 0
+    exponential: 1
   outputs:
   - {fileID: 5765902433490691002}
   midpoint: {fileID: 2658316667072905057}

--- a/Assets/Prefabs/GunParts/EnlargerExtension.prefab
+++ b/Assets/Prefabs/GunParts/EnlargerExtension.prefab
@@ -134,9 +134,9 @@ MonoBehaviour:
     multiplier: 0
     exponential: 0.5
   - name: CrosshairRadius
-    addition: 0
+    addition: 0.5
     multiplier: 0
-    exponential: 1.25
+    exponential: 1
   outputs:
   - {fileID: 932626616956480431}
   midpoint: {fileID: 5729402012261899082}

--- a/Assets/Prefabs/GunParts/EnlargerExtension.prefab
+++ b/Assets/Prefabs/GunParts/EnlargerExtension.prefab
@@ -133,6 +133,10 @@ MonoBehaviour:
     addition: 0
     multiplier: 0
     exponential: 0.5
+  - name: CrosshairRadius
+    addition: 0
+    multiplier: 0
+    exponential: 1.25
   outputs:
   - {fileID: 932626616956480431}
   midpoint: {fileID: 5729402012261899082}

--- a/Assets/Prefabs/GunParts/HatBarrel.prefab
+++ b/Assets/Prefabs/GunParts/HatBarrel.prefab
@@ -505,6 +505,7 @@ MonoBehaviour:
   outputs:
   - {fileID: 2006913084140856218}
   midpoint: {fileID: 3377161213218414738}
+  crossHairMode: 2
   attachmentPoints:
   - {fileID: 2006913084140856218}
   muzzleFlash: {fileID: 0}

--- a/Assets/Prefabs/GunParts/HatBarrel.prefab
+++ b/Assets/Prefabs/GunParts/HatBarrel.prefab
@@ -498,6 +498,10 @@ MonoBehaviour:
     addition: 0
     multiplier: 0
     exponential: 1.5
+  - name: CrosshairRadius
+    addition: 0.3
+    multiplier: 0
+    exponential: 1
   outputs:
   - {fileID: 2006913084140856218}
   midpoint: {fileID: 3377161213218414738}

--- a/Assets/Prefabs/GunParts/LazurBarrel.prefab
+++ b/Assets/Prefabs/GunParts/LazurBarrel.prefab
@@ -576,6 +576,10 @@ MonoBehaviour:
     addition: 0.3
     multiplier: 0
     exponential: 1
+  - name: CrosshairRadius
+    addition: 0.1
+    multiplier: 0
+    exponential: 1
   outputs:
   - {fileID: 2021858193588301184}
   midpoint: {fileID: 4423458652456300157}

--- a/Assets/Prefabs/GunParts/ShotgunBarrel.prefab
+++ b/Assets/Prefabs/GunParts/ShotgunBarrel.prefab
@@ -759,12 +759,13 @@ MonoBehaviour:
     multiplier: 0
     exponential: 1
   - name: CrosshairRadius
-    addition: 2
+    addition: 0
     multiplier: 0
     exponential: 1
   outputs:
   - {fileID: 5765902433490691002}
   midpoint: {fileID: 8314351826047603952}
+  crossHairMode: 1
   attachmentPoints:
   - {fileID: 5765902433490691002}
   muzzleFlash: {fileID: 261841362781268065}

--- a/Assets/Prefabs/GunParts/ShotgunBarrel.prefab
+++ b/Assets/Prefabs/GunParts/ShotgunBarrel.prefab
@@ -758,6 +758,10 @@ MonoBehaviour:
     addition: 2
     multiplier: 0
     exponential: 1
+  - name: CrosshairRadius
+    addition: 2
+    multiplier: 0
+    exponential: 1
   outputs:
   - {fileID: 5765902433490691002}
   midpoint: {fileID: 8314351826047603952}

--- a/Assets/Prefabs/GunParts/TelescopeExtension.prefab
+++ b/Assets/Prefabs/GunParts/TelescopeExtension.prefab
@@ -181,6 +181,10 @@ MonoBehaviour:
     addition: 0
     multiplier: 0
     exponential: 0.7
+  - name: CrosshairRadius
+    addition: 0
+    multiplier: 0
+    exponential: 0
   outputs:
   - {fileID: 32494311255358874}
   midpoint: {fileID: 6440842260644592729}

--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -2935,7 +2935,7 @@ RectTransform:
   m_GameObject: {fileID: 7459895803486625479}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.4, y: 0.4, z: 0.4}
+  m_LocalScale: {x: 0.8, y: 0.8, z: 0.8}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 4426932892002352228}
@@ -2979,7 +2979,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 0}
-  m_Type: 0
+  m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4

--- a/Assets/Prefabs/Input/Player.prefab
+++ b/Assets/Prefabs/Input/Player.prefab
@@ -453,7 +453,6 @@ MonoBehaviour:
   minRadius: 1
   collisionOffset: 0.3
   lookSensitivity: 5
-  InputManager: {fileID: 0}
 --- !u!1 &345906872987025452
 GameObject:
   m_ObjectHideFlags: 0
@@ -636,7 +635,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &3007082568263880838
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1680,7 +1679,7 @@ MonoBehaviour:
   healthMin: {r: 0.9607843, g: 0.2784314, b: 0.23921569, a: 1}
   ammoHud: {fileID: 6629533919243205533}
   ammoBar: {fileID: 4001729099187883475}
-  crosshair: {fileID: 1417967732049705392}
+  crosshair: {fileID: 657120002521229129}
   tweenDuration: 0.07
   chipBox: {fileID: 7552965056758612035}
   chipAmount: {fileID: 5281579252922457437}
@@ -2049,7 +2048,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &9053769341556837942
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2156,7 +2155,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5105759301842569025
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2850,7 +2849,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &4426932892002352228
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2918,6 +2917,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1417967732049705392}
+  - component: {fileID: 458658808717406828}
+  - component: {fileID: 657120002521229129}
   m_Layer: 5
   m_Name: Crosshair
   m_TagString: Untagged
@@ -2949,6 +2950,44 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &458658808717406828
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7459895803486625479}
+  m_CullTransparentMesh: 1
+--- !u!114 &657120002521229129
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7459895803486625479}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: -876546973899608171, guid: 7e9b4ecd48e3c24449e0f28442b37d31, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8105111567943840941
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Augment/GunBarrel.cs
+++ b/Assets/Scripts/Augment/GunBarrel.cs
@@ -1,9 +1,12 @@
 using UnityEngine;
 using UnityEngine.VFX;
+using static GunStats;
 
 [RequireComponent(typeof(ProjectileController))]
 public class GunBarrel : Augment
 {
+    [SerializeField]
+    private CrossHairModes crossHairMode;
     // Where to attach extensions
     public Transform[] attachmentPoints;
 
@@ -15,9 +18,15 @@ public class GunBarrel : Augment
 
     private GunController gunController;
 
-    private void Start()
+    private void Awake()
     {
         gunController = transform.parent.GetComponent<GunController>();
+        if (gunController)
+            gunController.stats.CrossHairMode = crossHairMode;
+    }
+
+    private void Start()
+    {
         if (!gunController)
             return;
 

--- a/Assets/Scripts/Augment/GunStats.cs
+++ b/Assets/Scripts/Augment/GunStats.cs
@@ -151,4 +151,7 @@ public class GunStats : ScriptableObject
     [SerializeField]
     private ModifiableFloat screenShakeFactor = new ModifiableFloat(1f);
     public ModifiableFloat ScreenShakeFactor => screenShakeFactor;
+    [SerializeField]
+    private ModifiableFloat crosshairRadius = new ModifiableFloat(1f);
+    public ModifiableFloat CrosshairRadius => crosshairRadius;
 }

--- a/Assets/Scripts/Augment/GunStats.cs
+++ b/Assets/Scripts/Augment/GunStats.cs
@@ -151,6 +151,13 @@ public class GunStats : ScriptableObject
     [SerializeField]
     private ModifiableFloat screenShakeFactor = new ModifiableFloat(1f);
     public ModifiableFloat ScreenShakeFactor => screenShakeFactor;
+    public enum CrossHairModes
+    {
+        Default,
+        Shotgun,
+        Hat,
+    }
+    public CrossHairModes CrossHairMode { get; set; }
     [SerializeField]
     private ModifiableFloat crosshairRadius = new ModifiableFloat(1f);
     public ModifiableFloat CrosshairRadius => crosshairRadius;

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -411,7 +411,7 @@ public class PlayerManager : NetworkBehaviour
 
     private void UpdateHudCrosshair(GunStats stats)
     {
-        HUDController.UpdateOnInitialize(stats.CrosshairRadius.Value());
+        HUDController.UpdateOnInitialize(stats);
     }
 
     private void TryPlaceBid(InputAction.CallbackContext ctx)

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -409,6 +409,11 @@ public class PlayerManager : NetworkBehaviour
         hudController.UpdateOnReload(ammo / magazine);
     }
 
+    private void UpdateHudCrosshair(GunStats stats)
+    {
+        HUDController.UpdateOnInitialize(stats.CrosshairRadius.Value());
+    }
+
     private void TryPlaceBid(InputAction.CallbackContext ctx)
     {
         if (!selectedBiddingPlatform) return;
@@ -484,6 +489,7 @@ public class PlayerManager : NetworkBehaviour
             gunController.onFireEnd += ScreenShake;
             gunController.onFireEnd += UpdateHudFire;
             gunController.onReload += UpdateHudReload;
+            UpdateHudCrosshair(gunController.stats);
             gunController.projectile.OnHitboxCollision += hudController.HitmarkAnimation;
         }
         playerIK.LeftHandIKTarget = gunController.LeftHandTarget;

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -490,7 +490,7 @@ public class PlayerManager : NetworkBehaviour
             gunController.onFireEnd += UpdateHudFire;
             gunController.onReload += UpdateHudReload;
             UpdateHudCrosshair(gunController.stats);
-            gunController.projectile.OnHitboxCollision += hudController.HitmarkAnimation;
+            gunController.projectile.OnHitboxCollision += hudController.HitAnimation;
         }
         playerIK.LeftHandIKTarget = gunController.LeftHandTarget;
         if (gunController.RightHandTarget)

--- a/Assets/Scripts/HitboxController.cs
+++ b/Assets/Scripts/HitboxController.cs
@@ -13,5 +13,9 @@ public class HitboxController : MonoBehaviour
         if (!health.enabled)
             return;
         health?.DealDamage(info);
+
+        if (info.sourcePlayer != null)
+            if (info.sourcePlayer.HUDController != null)
+                info.sourcePlayer.HUDController.DamageAnimation();
     }
 }

--- a/Assets/Scripts/UI/PlayerHUDController.cs
+++ b/Assets/Scripts/UI/PlayerHUDController.cs
@@ -33,7 +33,8 @@ public class PlayerHUDController : MonoBehaviour
     private SpriteRenderer ammoBar;
 
     [SerializeField]
-    private RectTransform crosshair;
+    private Image crosshair;
+    private Material crosshairMaterial;
 
     private Material ammoCapacityMaterial;
 
@@ -105,13 +106,18 @@ public class PlayerHUDController : MonoBehaviour
     private const float lineVelocityDampeningX = 0.25f;
     // Dampen how much vertical velocity should influence center of speedlines
     private const float lineVelocityDampeningY = 0.1f;
-    private Vector3 defaultCrosshairScale;
+    private float crosshairCrossScale = 1.0f;
 
     [SerializeField]
     private RectTransform scopeZoom;
     private int scopeTween;
     private int hitMarkTween;
 
+    private void Awake()
+    {
+        crosshairMaterial = Instantiate(crosshair.material);
+        crosshair.material = crosshairMaterial;
+    }
 
     void Start()
     {
@@ -127,8 +133,6 @@ public class PlayerHUDController : MonoBehaviour
         ammoCapacityMaterial = Instantiate(ammoBar.material);
         ammoBar.material = ammoCapacityMaterial;
         ammoCapacityMaterial.SetFloat("_Arc2", 0);
-
-        defaultCrosshairScale = crosshair.localScale;
 
         originalChipY = chipBox.anchoredPosition.y;
         if (!MatchController.Singleton || PlayerInputManagerController.Singleton.LocalPlayerInputs.Count() == 1)
@@ -320,7 +324,7 @@ public class PlayerHUDController : MonoBehaviour
         var halfWidth = hud.sizeDelta.x / 2;
         var halfHeight = hud.sizeDelta.y / 2;
 
-        crosshair.anchoredPosition = (new Vector2(halfWidth * x, halfHeight * y));
+        crosshair.rectTransform.anchoredPosition = (new Vector2(halfWidth * x, halfHeight * y));
     }
 
     public void HitmarkAnimation(HitboxController other, ref ProjectileState state)
@@ -328,8 +332,18 @@ public class PlayerHUDController : MonoBehaviour
         if (LeanTween.isTweening(hitMarkTween))
         {
             LeanTween.cancel(hitMarkTween);
-            crosshair.localScale = defaultCrosshairScale;
+            SetCrossScale(crosshairCrossScale);
         }
-        hitMarkTween = crosshair.LeanScale(new Vector3(1.5f, 1.5f, 1.5f), 0.2f).setEasePunch().id;
+        hitMarkTween = LeanTween.value(crosshair.gameObject, SetCrossScale, crosshairCrossScale, 5f, 0.2f).setEasePunch().id;
+    }
+
+    private void SetCrossScale(float scale)
+    {
+        crosshairMaterial.SetFloat("_CrossSize", scale);
+    }
+
+    public void UpdateOnInitialize(float radius)
+    {
+        crosshairMaterial.SetFloat("_Radius", radius == 0f ? 1f : 1f/radius);
     }
 }

--- a/Assets/Scripts/UI/PlayerHUDController.cs
+++ b/Assets/Scripts/UI/PlayerHUDController.cs
@@ -3,6 +3,8 @@ using UnityEngine.UI;
 using System.Linq;
 using TMPro;
 using UnityEngine.Serialization;
+using static GunStats;
+using System;
 
 public class PlayerHUDController : MonoBehaviour
 {
@@ -345,7 +347,7 @@ public class PlayerHUDController : MonoBehaviour
             LeanTween.cancel(hitMarkTween);
             SetHitScale(0f);
         }
-        hitMarkTween = LeanTween.value(crosshair.gameObject, SetHitScale, 0f, 1.5f, 0.2f).setEasePunch().id;
+        hitMarkTween = LeanTween.value(crosshair.gameObject, SetHitScale, 0f, 1.5f, 0.4f).setEasePunch().id;
     }
 
     private void SetCrossScale(float scale)
@@ -358,8 +360,15 @@ public class PlayerHUDController : MonoBehaviour
         crosshairMaterial.SetFloat("_HitMarkerRadius", scale);
     }
 
-    public void UpdateOnInitialize(float radius)
+    public void UpdateOnInitialize(GunStats stats)
     {
-        crosshairMaterial.SetFloat("_Radius", radius == 0f ? 1f : 1f/radius);
+        crosshairMaterial.SetFloat("_Radius", stats.CrosshairRadius.Value() == 0f ? 0f : 1f/stats.CrosshairRadius.Value());
+
+        // Has to be done this way as enum keywords in reality are a set of boolean keywords...
+        foreach (CrossHairModes mode in Enum.GetValues(typeof(CrossHairModes)))
+            if (mode != stats.CrossHairMode)
+                crosshairMaterial.DisableKeyword("_MODE_" + mode.ToString().ToUpper());
+            else
+                crosshairMaterial.EnableKeyword("_MODE_" + mode.ToString().ToUpper());
     }
 }

--- a/Assets/Scripts/UI/PlayerHUDController.cs
+++ b/Assets/Scripts/UI/PlayerHUDController.cs
@@ -111,6 +111,7 @@ public class PlayerHUDController : MonoBehaviour
     [SerializeField]
     private RectTransform scopeZoom;
     private int scopeTween;
+    private int hitTween;
     private int hitMarkTween;
 
     private void Awake()
@@ -327,19 +328,34 @@ public class PlayerHUDController : MonoBehaviour
         crosshair.rectTransform.anchoredPosition = (new Vector2(halfWidth * x, halfHeight * y));
     }
 
-    public void HitmarkAnimation(HitboxController other, ref ProjectileState state)
+    public void HitAnimation(HitboxController other, ref ProjectileState state)
+    {
+        if (LeanTween.isTweening(hitTween))
+        {
+            LeanTween.cancel(hitTween);
+            SetCrossScale(crosshairCrossScale);
+        }
+        hitTween = LeanTween.value(crosshair.gameObject, SetCrossScale, crosshairCrossScale, 2.5f, 0.4f).setEasePunch().id;
+    }
+
+    public void DamageAnimation()
     {
         if (LeanTween.isTweening(hitMarkTween))
         {
             LeanTween.cancel(hitMarkTween);
-            SetCrossScale(crosshairCrossScale);
+            SetHitScale(0f);
         }
-        hitMarkTween = LeanTween.value(crosshair.gameObject, SetCrossScale, crosshairCrossScale, 5f, 0.2f).setEasePunch().id;
+        hitMarkTween = LeanTween.value(crosshair.gameObject, SetHitScale, 0f, 1.5f, 0.2f).setEasePunch().id;
     }
 
     private void SetCrossScale(float scale)
     {
         crosshairMaterial.SetFloat("_CrossSize", scale);
+    }
+
+    private void SetHitScale(float scale)
+    {
+        crosshairMaterial.SetFloat("_HitMarkerRadius", scale);
     }
 
     public void UpdateOnInitialize(float radius)

--- a/Assets/Shaders/CrossHair.hlsl
+++ b/Assets/Shaders/CrossHair.hlsl
@@ -12,13 +12,19 @@ float sdCross_float( in float2 p, in float2 b, float r )
     return sign(k)*length(max(w,0.0)) + r;
 }
 
+float sdRoundedX_float( float2 p, float w, float r )
+{
+    p = abs(p);
+    return max(length(p-min(p.x+p.y,w)*0.5) - r, -1. * (length(p) - 0.5));
+}
+
 float crossSDF_float(float2 pos)
 {
     return abs(sdCross_float(pos, float2(0.5, 0.1), 0.1))-0.05;
 }
 
 
-void CrossHair_float(float2 UV, float crossSize, float circleRadius, out float Distance)
+void CrossHair_float(float2 UV, float crossSize, float circleRadius, float hitMarkerRadius, out float Distance)
 {
-	Distance = min(sphereSDF_float(UV * 2.5 * circleRadius), crossSDF_float(UV * crossSize));
+	Distance = min(min(sphereSDF_float(UV * 2.5 * circleRadius), crossSDF_float(UV * crossSize)), sdRoundedX_float(UV, hitMarkerRadius, 0.1));
 }

--- a/Assets/Shaders/CrossHair.hlsl
+++ b/Assets/Shaders/CrossHair.hlsl
@@ -23,7 +23,6 @@ float crossSDF_float(float2 pos)
     return abs(sdCross_float(pos, float2(0.5, 0.1), 0.1))-0.05;
 }
 
-
 void CrossHair_float(float2 UV, float crossSize, float circleRadius, float hitMarkerRadius, out float Distance)
 {
 	Distance = min(min(sphereSDF_float(UV * 2.5 * circleRadius), crossSDF_float(UV * crossSize)), sdRoundedX_float(UV, hitMarkerRadius, 0.1));

--- a/Assets/Shaders/CrossHair.hlsl
+++ b/Assets/Shaders/CrossHair.hlsl
@@ -1,0 +1,24 @@
+float sphereSDF_float(float2 pos)
+{
+    return abs(length(pos) - 1.)-0.05;
+}
+
+float sdCross_float( in float2 p, in float2 b, float r ) 
+{
+    p = abs(p); p = (p.y>p.x) ? p.yx : p.xy;
+    float2  q = p - b;
+    float k = max(q.y,q.x);
+    float2  w = (k>0.0) ? q : float2(b.y-p.x,-k);
+    return sign(k)*length(max(w,0.0)) + r;
+}
+
+float crossSDF_float(float2 pos)
+{
+    return abs(sdCross_float(pos, float2(0.5, 0.1), 0.1))-0.05;
+}
+
+
+void CrossHair_float(float2 UV, float crossSize, float circleRadius, out float Distance)
+{
+	Distance = min(sphereSDF_float(UV * 2.5 * circleRadius), crossSDF_float(UV * crossSize));
+}

--- a/Assets/Shaders/CrossHair.hlsl.meta
+++ b/Assets/Shaders/CrossHair.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 947e0a528d36a0045b168b689bd989f5
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/CrossHairHat.hlsl
+++ b/Assets/Shaders/CrossHairHat.hlsl
@@ -1,0 +1,63 @@
+float sphereSDFHat_float(float2 pos)
+{
+    return abs(length(pos) - 1.)-0.05;
+}
+
+float sdCrossHat_float( in float2 p, in float2 b, float r ) 
+{
+    p = abs(p); p = (p.y>p.x) ? p.yx : p.xy;
+    float2  q = p - b;
+    float k = max(q.y,q.x);
+    float2  w = (k>0.0) ? q : float2(b.y-p.x,-k);
+    return sign(k)*length(max(w,0.0)) + r;
+}
+
+float sdRoundedXHat_float( float2 p, float w, float r )
+{
+    p = abs(p);
+    return max(length(p-min(p.x+p.y,w)*0.5) - r, -1. * (length(p) - 0.5));
+}
+
+float crossSDFHat_float(float2 pos, float r)
+{
+    return abs(sdCrossHat_float(pos, float2(0.5 * r, 0.1 * r), 0.1*r))-0.05*r;
+}
+
+
+float sdBoxHat_float( float2 p, float2 b )
+{
+    float2 d = abs(p)-b;
+    return length(max(d,0.0)) + min(max(d.x,d.y),0.0);
+}
+float sdHexagonHat_float( float2 p, in float r )
+{
+    float3 k = float3(-0.866025404,0.5,0.577350269);
+    p = abs(p);
+    p -= 2.0*min(dot(k.xy,p),0.0)*k.xy;
+    p -= float2(clamp(p.x, -k.z*r, k.z*r), r);
+    return length(p)*sign(p.y);
+}
+
+float sdArcHat_float( float2 p, float2 sc, in float ra, float rb )
+{
+    p.x = abs(p.x);
+    return ((sc.y*p.x>sc.x*p.y) ? length(p-sc*ra) : 
+                                  abs(length(p)-ra)) - rb;
+}
+
+float hat_float(float2 pos)
+{
+    return 
+        max( 
+            min(
+                max(sdBoxHat_float(pos-float2(0.,0.5), float2(.5, .8)),sdHexagonHat_float(pos- float2(0.,-0.1), 0.4)-0.1),
+                sdArcHat_float(float2(pos.x, pos.y*-1. + 3.7), float2(sin(0.2),cos(0.2)), 4., 0.04)
+                ),
+            -1. * max(sdBoxHat_float(pos*1.1-float2(0.,0.5), float2(.5, .8)), sdHexagonHat_float(pos*1.1- float2(0.,-0.1), 0.4)-0.1)
+        );
+}
+
+void CrossHairHat_float(float2 UV, float crossSize, float circleRadius, float hitMarkerRadius, out float Distance)
+{
+	Distance = min(min(hat_float(UV * circleRadius + float2(0., 0.05)), crossSDFHat_float(UV * crossSize, 1.)), sdRoundedXHat_float(UV, hitMarkerRadius, 0.1));
+}

--- a/Assets/Shaders/CrossHairHat.hlsl.meta
+++ b/Assets/Shaders/CrossHairHat.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5498a3c6282026f46b6d2de20b6bc801
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/CrossHairShotgun.hlsl
+++ b/Assets/Shaders/CrossHairShotgun.hlsl
@@ -1,0 +1,41 @@
+float sphereSDFShotgun_float(float2 pos)
+{
+    return abs(length(pos) - 1.)-0.05;
+}
+
+float sdCrossShotgun_float( in float2 p, in float2 b, float r ) 
+{
+    p = abs(p); p = (p.y>p.x) ? p.yx : p.xy;
+    float2  q = p - b;
+    float k = max(q.y,q.x);
+    float2  w = (k>0.0) ? q : float2(b.y-p.x,-k);
+    return sign(k)*length(max(w,0.0)) + r;
+}
+
+float sdRoundedXShotgun_float( float2 p, float w, float r )
+{
+    p = abs(p);
+    return max(length(p-min(p.x+p.y,w)*0.5) - r, -1. * (length(p) - 0.5));
+}
+
+float crossSDFShotgun_float(float2 pos, float r)
+{
+    return abs(sdCrossShotgun_float(pos, float2(0.5 * r, 0.1 * r), 0.1*r))-0.05*r;
+}
+
+
+float sdBox_float(float2 p, float2 b )
+{
+    float2 d = abs(p)-b;
+    return length(max(d,0.0)) + min(max(d.x,d.y),0.0);
+}
+
+float shotgun_float(float2 pos)
+{
+    return max(sdBox_float(pos, float2(.5, .5))-0.1, -1. * crossSDFShotgun_float(pos, 8.));
+}
+
+void CrossHairShotgun_float(float2 UV, float crossSize, float circleRadius, float hitMarkerRadius, out float Distance)
+{
+	Distance = min(min(shotgun_float(UV * circleRadius), crossSDFShotgun_float(UV * crossSize, 1.)), sdRoundedXShotgun_float(UV, hitMarkerRadius, 0.1));
+}

--- a/Assets/Shaders/CrossHairShotgun.hlsl.meta
+++ b/Assets/Shaders/CrossHairShotgun.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 97b563266b995af4aac2a76b8bbf0ed8
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/Crosshair.shadergraph
+++ b/Assets/Shaders/Crosshair.shadergraph
@@ -1,0 +1,1687 @@
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.GraphData",
+    "m_ObjectId": "13611cb01fca464882648a3d87a34bd3",
+    "m_Properties": [
+        {
+            "m_Id": "d32f3f30fc7742f196a78201003746a1"
+        },
+        {
+            "m_Id": "61615a0e7c8b4f288be39419ca338239"
+        },
+        {
+            "m_Id": "39003c110ecc4efeb92e0a4f81adf62c"
+        }
+    ],
+    "m_Keywords": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "bf5281d3c58f44b289d6023523a86898"
+        }
+    ],
+    "m_Nodes": [
+        {
+            "m_Id": "b142956d24634a8c97fd9a50534f85ed"
+        },
+        {
+            "m_Id": "195e43e3329844d48d03dde9e027eebd"
+        },
+        {
+            "m_Id": "54f4579aeb3341eaa6814ea8ecb66e6b"
+        },
+        {
+            "m_Id": "c7e1f851e1914dfa83847404d6a66440"
+        },
+        {
+            "m_Id": "7d37a15d571445acb8c4e83e1261250d"
+        },
+        {
+            "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
+        },
+        {
+            "m_Id": "e9d7b5b1ee724174a7ec292bdcd22c5e"
+        },
+        {
+            "m_Id": "9ed9ea0c7fa74ceeb8197100c740251f"
+        },
+        {
+            "m_Id": "16171b4d30a448be8e65375d78988610"
+        },
+        {
+            "m_Id": "347bc1c64428488085911aea9ecd6920"
+        },
+        {
+            "m_Id": "bd1450a953c049f0a08aab0a999ef74f"
+        },
+        {
+            "m_Id": "423a85ed24744f1f8a7d32d7bbe4b985"
+        },
+        {
+            "m_Id": "20687ec0ab1046e4b00ce3f68092cee5"
+        },
+        {
+            "m_Id": "20d6ebc89b914b0c83d3f8b1fe771ce0"
+        }
+    ],
+    "m_GroupDatas": [],
+    "m_StickyNoteDatas": [],
+    "m_Edges": [
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "16171b4d30a448be8e65375d78988610"
+                },
+                "m_SlotId": 3
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "20687ec0ab1046e4b00ce3f68092cee5"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "20d6ebc89b914b0c83d3f8b1fe771ce0"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "20d6ebc89b914b0c83d3f8b1fe771ce0"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "c7e1f851e1914dfa83847404d6a66440"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "347bc1c64428488085911aea9ecd6920"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
+                },
+                "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "423a85ed24744f1f8a7d32d7bbe4b985"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "20687ec0ab1046e4b00ce3f68092cee5"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "9ed9ea0c7fa74ceeb8197100c740251f"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "e9d7b5b1ee724174a7ec292bdcd22c5e"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "bd1450a953c049f0a08aab0a999ef74f"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
+                },
+                "m_SlotId": 3
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e9d7b5b1ee724174a7ec292bdcd22c5e"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "20d6ebc89b914b0c83d3f8b1fe771ce0"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e9d7b5b1ee724174a7ec292bdcd22c5e"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "7d37a15d571445acb8c4e83e1261250d"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "9ed9ea0c7fa74ceeb8197100c740251f"
+                },
+                "m_SlotId": 1
+            }
+        }
+    ],
+    "m_VertexContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 0.0
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "b142956d24634a8c97fd9a50534f85ed"
+            },
+            {
+                "m_Id": "195e43e3329844d48d03dde9e027eebd"
+            },
+            {
+                "m_Id": "54f4579aeb3341eaa6814ea8ecb66e6b"
+            }
+        ]
+    },
+    "m_FragmentContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 200.0
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "c7e1f851e1914dfa83847404d6a66440"
+            },
+            {
+                "m_Id": "7d37a15d571445acb8c4e83e1261250d"
+            }
+        ]
+    },
+    "m_PreviewData": {
+        "serializedMesh": {
+            "m_SerializedMesh": "{\"mesh\":{\"instanceID\":0}}",
+            "m_Guid": ""
+        },
+        "preventRotation": false
+    },
+    "m_Path": "Shader Graphs",
+    "m_GraphPrecision": 1,
+    "m_PreviewMode": 2,
+    "m_OutputNode": {
+        "m_Id": ""
+    },
+    "m_ActiveTargets": [
+        {
+            "m_Id": "7fc333d745a84bbd9a1102b11d57db5a"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.TilingAndOffsetNode",
+    "m_ObjectId": "16171b4d30a448be8e65375d78988610",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Tiling And Offset",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1074.4000244140625,
+            "y": -45.599998474121097,
+            "width": 208.0,
+            "height": 325.6000061035156
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "2eb79d3b3c2646db93e01d7b63d11712"
+        },
+        {
+            "m_Id": "bbddf26580b945ed92ae67da5fc64c03"
+        },
+        {
+            "m_Id": "98ba027064354e9789eb293fc71fb907"
+        },
+        {
+            "m_Id": "162e7564971544c8bdfba90d0eee842f"
+        }
+    ],
+    "synonyms": [
+        "pan",
+        "scale"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
+    "m_ObjectId": "162e7564971544c8bdfba90d0eee842f",
+    "m_Id": 3,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "173c16812a0a423ea9b3d3dd5a46c568",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 2.0,
+        "e01": 2.0,
+        "e02": 2.0,
+        "e03": 2.0,
+        "e10": 2.0,
+        "e11": 2.0,
+        "e12": 2.0,
+        "e13": 2.0,
+        "e20": 2.0,
+        "e21": 2.0,
+        "e22": 2.0,
+        "e23": 2.0,
+        "e30": 2.0,
+        "e31": 2.0,
+        "e32": 2.0,
+        "e33": 2.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "17c90dbcfd354fd48c3f21d2a425b180",
+    "m_Id": 1,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "194a705046b64931a090f181ed7c4e88",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 2.0,
+        "e01": 2.0,
+        "e02": 2.0,
+        "e03": 2.0,
+        "e10": 2.0,
+        "e11": 2.0,
+        "e12": 2.0,
+        "e13": 2.0,
+        "e20": 2.0,
+        "e21": 2.0,
+        "e22": 2.0,
+        "e23": 2.0,
+        "e30": 2.0,
+        "e31": 2.0,
+        "e32": 2.0,
+        "e33": 2.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "195e43e3329844d48d03dde9e027eebd",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Normal",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "f2ac6e99520042128b2c6a3a56e63917"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Normal"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "1fe619ab1c344729b4f4c7f0eb3fade3",
+    "m_Id": 1,
+    "m_DisplayName": "Distance",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Distance",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.OneMinusNode",
+    "m_ObjectId": "20687ec0ab1046e4b00ce3f68092cee5",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "One Minus",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -362.39996337890627,
+            "y": 60.800018310546878,
+            "width": 208.00001525878907,
+            "height": 277.5999755859375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "8102d6745a2343aa95bc7b82c5b39302"
+        },
+        {
+            "m_Id": "17c90dbcfd354fd48c3f21d2a425b180"
+        }
+    ],
+    "synonyms": [
+        "complement",
+        "invert",
+        "opposite"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
+    "m_ObjectId": "20d6ebc89b914b0c83d3f8b1fe771ce0",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Multiply",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -258.3999938964844,
+            "y": 171.1999969482422,
+            "width": 208.0,
+            "height": 301.60003662109377
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "390891efa6144dca9590b2ecb0fc2e86"
+        },
+        {
+            "m_Id": "173c16812a0a423ea9b3d3dd5a46c568"
+        },
+        {
+            "m_Id": "a9432a81757e4977b91267e5610d5851"
+        }
+    ],
+    "synonyms": [
+        "multiplication",
+        "times",
+        "x"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "21d9a14b5fc94dfe9c61bcd9d705a660",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ScreenPositionMaterialSlot",
+    "m_ObjectId": "2809696838954d26ab5a3855fb4d161a",
+    "m_Id": 0,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": [],
+    "m_ScreenSpaceType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
+    "m_ObjectId": "2eb79d3b3c2646db93e01d7b63d11712",
+    "m_Id": 0,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": [],
+    "m_Channel": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "347bc1c64428488085911aea9ecd6920",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1021.5999755859375,
+            "y": 439.20001220703127,
+            "width": 127.20001220703125,
+            "height": 33.5999755859375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "b9e75994b86e49a09e55ebc71e333c32"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "d32f3f30fc7742f196a78201003746a1"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
+    "m_ObjectId": "39003c110ecc4efeb92e0a4f81adf62c",
+    "m_Guid": {
+        "m_GuidSerialized": "2eff7700-881d-42be-820b-9e3bb80cd327"
+    },
+    "m_Name": "MainTex",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "MainTex",
+    "m_DefaultReferenceName": "_MainTex",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
+    "m_Modifiable": true,
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "390891efa6144dca9590b2ecb0fc2e86",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SceneColorNode",
+    "m_ObjectId": "423a85ed24744f1f8a7d32d7bbe4b985",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Scene Color",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -522.952880859375,
+            "y": 100.04317474365235,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "2809696838954d26ab5a3855fb4d161a"
+        },
+        {
+            "m_Id": "c0cb15e674d74932893ca57f7c322df6"
+        }
+    ],
+    "synonyms": [
+        "screen buffer"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "54f4579aeb3341eaa6814ea8ecb66e6b",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Tangent",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c2cdb86ab3c14d6d8326ffeb631ea316"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Tangent"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PositionMaterialSlot",
+    "m_ObjectId": "5d3e01fd55864089b0229e704bddf796",
+    "m_Id": 0,
+    "m_DisplayName": "Position",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
+    "m_ObjectId": "5ddf766b2c9b4783a60ec921ab122ada",
+    "m_Id": 0,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "61615a0e7c8b4f288be39419ca338239",
+    "m_Guid": {
+        "m_GuidSerialized": "6a11ab54-fb2f-4c8a-a32f-379ecbfaf690"
+    },
+    "m_Name": "Radius",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Radius",
+    "m_DefaultReferenceName": "_Radius",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 1.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
+    "m_ObjectId": "70c115937656487d94e7ba0ca2da2e32",
+    "m_Id": 0,
+    "m_DisplayName": "Base Color",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "BaseColor",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.5,
+        "y": 0.5,
+        "z": 0.5
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_ColorMode": 0,
+    "m_DefaultColor": {
+        "r": 0.5,
+        "g": 0.5,
+        "b": 0.5,
+        "a": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "7213952eb09a4f819a3d4d1124b0b25f",
+    "m_Id": 2,
+    "m_DisplayName": "CrossSize",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "CrossSize",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "7d37a15d571445acb8c4e83e1261250d",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Alpha",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "e2672f8b754c4d17a492c20e5fb36d03"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Alpha"
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
+    "m_ObjectId": "7fc333d745a84bbd9a1102b11d57db5a",
+    "m_Datas": [],
+    "m_ActiveSubTarget": {
+        "m_Id": "c5e520cc4e7349cc900ed6357f2b6dc9"
+    },
+    "m_AllowMaterialOverride": false,
+    "m_SurfaceType": 0,
+    "m_ZTestMode": 4,
+    "m_ZWriteControl": 0,
+    "m_AlphaMode": 0,
+    "m_RenderFace": 2,
+    "m_AlphaClip": false,
+    "m_CastShadows": true,
+    "m_ReceiveShadows": true,
+    "m_SupportsLODCrossFade": false,
+    "m_CustomEditorGUI": "",
+    "m_SupportVFX": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "8102d6745a2343aa95bc7b82c5b39302",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
+    "m_ObjectId": "98ba027064354e9789eb293fc71fb907",
+    "m_Id": 2,
+    "m_DisplayName": "Offset",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Offset",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": -1.0,
+        "y": -1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
+    "m_ObjectId": "9ed9ea0c7fa74ceeb8197100c740251f",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Multiply",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -502.962646484375,
+            "y": 299.4373779296875,
+            "width": 208.0,
+            "height": 301.6000061035156
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "9f11396fa3664066ad123ceacd6762dc"
+        },
+        {
+            "m_Id": "194a705046b64931a090f181ed7c4e88"
+        },
+        {
+            "m_Id": "21d9a14b5fc94dfe9c61bcd9d705a660"
+        }
+    ],
+    "synonyms": [
+        "multiplication",
+        "times",
+        "x"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "9f11396fa3664066ad123ceacd6762dc",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": -1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "a9432a81757e4977b91267e5610d5851",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "a979b08289834e069512937ffd2faf6c",
+    "m_Id": 3,
+    "m_DisplayName": "CircleRadius",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "CircleRadius",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "b142956d24634a8c97fd9a50534f85ed",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Position",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "5d3e01fd55864089b0229e704bddf796"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Position"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "b9e75994b86e49a09e55ebc71e333c32",
+    "m_Id": 0,
+    "m_DisplayName": "CrossSize",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
+    "m_ObjectId": "bbddf26580b945ed92ae67da5fc64c03",
+    "m_Id": 1,
+    "m_DisplayName": "Tiling",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Tiling",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 2.0,
+        "y": 2.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "bd1450a953c049f0a08aab0a999ef74f",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1315.199951171875,
+            "y": 524.7999877929688,
+            "width": 110.39990234375,
+            "height": 33.60003662109375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c0058e805f6240b8948e8e9b093bbdc6"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "61615a0e7c8b4f288be39419ca338239"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "bf5281d3c58f44b289d6023523a86898",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "61615a0e7c8b4f288be39419ca338239"
+        },
+        {
+            "m_Id": "d32f3f30fc7742f196a78201003746a1"
+        },
+        {
+            "m_Id": "39003c110ecc4efeb92e0a4f81adf62c"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "c0058e805f6240b8948e8e9b093bbdc6",
+    "m_Id": 0,
+    "m_DisplayName": "Radius",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "c0cb15e674d74932893ca57f7c322df6",
+    "m_Id": 1,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
+    "m_ObjectId": "c2cdb86ab3c14d6d8326ffeb631ea316",
+    "m_Id": 0,
+    "m_DisplayName": "Tangent",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "c5bb594d75d544ce8eafa0e3c5694e29",
+    "m_Id": 0,
+    "m_DisplayName": "Edge",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Edge",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalSpriteUnlitSubTarget",
+    "m_ObjectId": "c5e520cc4e7349cc900ed6357f2b6dc9"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "c7e1f851e1914dfa83847404d6a66440",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.BaseColor",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "70c115937656487d94e7ba0ca2da2e32"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.BaseColor"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "cb232694c0fd466e86a9c0dbd0273da8",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "ccd47f5c439346e7b6b8ab3341a6e73e",
+    "m_Id": 1,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "d32f3f30fc7742f196a78201003746a1",
+    "m_Guid": {
+        "m_GuidSerialized": "736eb2ea-27cd-4c3b-87bd-5a50684f805b"
+    },
+    "m_Name": "CrossSize",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "CrossSize",
+    "m_DefaultReferenceName": "_CrossSize",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 1.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "e2672f8b754c4d17a492c20e5fb36d03",
+    "m_Id": 0,
+    "m_DisplayName": "Alpha",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Alpha",
+    "m_StageCapability": 2,
+    "m_Value": 1.0,
+    "m_DefaultValue": 1.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.StepNode",
+    "m_ObjectId": "e9d7b5b1ee724174a7ec292bdcd22c5e",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Step",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -258.3999938964844,
+            "y": 449.6000061035156,
+            "width": 208.0,
+            "height": 301.6000061035156
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c5bb594d75d544ce8eafa0e3c5694e29"
+        },
+        {
+            "m_Id": "ccd47f5c439346e7b6b8ab3341a6e73e"
+        },
+        {
+            "m_Id": "cb232694c0fd466e86a9c0dbd0273da8"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.CustomFunctionNode",
+    "m_ObjectId": "ef5bd6ae10c045938b52ca9c8926f784",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "CrossHair (Custom Function)",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -762.4000244140625,
+            "y": 384.0,
+            "width": 212.0,
+            "height": 301.5999755859375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "5ddf766b2c9b4783a60ec921ab122ada"
+        },
+        {
+            "m_Id": "7213952eb09a4f819a3d4d1124b0b25f"
+        },
+        {
+            "m_Id": "a979b08289834e069512937ffd2faf6c"
+        },
+        {
+            "m_Id": "1fe619ab1c344729b4f4c7f0eb3fade3"
+        }
+    ],
+    "synonyms": [
+        "code",
+        "HLSL"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SourceType": 0,
+    "m_FunctionName": "CrossHair",
+    "m_FunctionSource": "947e0a528d36a0045b168b689bd989f5",
+    "m_FunctionBody": "Enter function body here..."
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "f2ac6e99520042128b2c6a3a56e63917",
+    "m_Id": 0,
+    "m_DisplayName": "Normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+

--- a/Assets/Shaders/Crosshair.shadergraph
+++ b/Assets/Shaders/Crosshair.shadergraph
@@ -16,7 +16,11 @@
             "m_Id": "187b92def2fb4ca685fae44d6a779b0d"
         }
     ],
-    "m_Keywords": [],
+    "m_Keywords": [
+        {
+            "m_Id": "4489a17b3bc344a483682eba4f780dee"
+        }
+    ],
     "m_Dropdowns": [],
     "m_CategoryData": [
         {
@@ -58,19 +62,22 @@
             "m_Id": "bd1450a953c049f0a08aab0a999ef74f"
         },
         {
-            "m_Id": "423a85ed24744f1f8a7d32d7bbe4b985"
-        },
-        {
-            "m_Id": "20687ec0ab1046e4b00ce3f68092cee5"
-        },
-        {
-            "m_Id": "20d6ebc89b914b0c83d3f8b1fe771ce0"
-        },
-        {
             "m_Id": "69ee95579277414b976cc4f92ccee9b9"
         },
         {
             "m_Id": "1e6635b34dba4905bddc0eb0019d1e95"
+        },
+        {
+            "m_Id": "860760b78617487e9d197a9b00f955ec"
+        },
+        {
+            "m_Id": "2b5cf5822378467c8ffa4e4037ea7b1f"
+        },
+        {
+            "m_Id": "cf248b5ee89947afa639605cec3508ee"
+        },
+        {
+            "m_Id": "f36957f8bb334884ae1c5cfd6aa3f78c"
         }
     ],
     "m_GroupDatas": [],
@@ -85,7 +92,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
+                    "m_Id": "f36957f8bb334884ae1c5cfd6aa3f78c"
                 },
                 "m_SlotId": 0
             }
@@ -107,29 +114,43 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "20687ec0ab1046e4b00ce3f68092cee5"
+                    "m_Id": "2b5cf5822378467c8ffa4e4037ea7b1f"
                 },
-                "m_SlotId": 1
+                "m_SlotId": 0
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "20d6ebc89b914b0c83d3f8b1fe771ce0"
+                    "m_Id": "9ed9ea0c7fa74ceeb8197100c740251f"
                 },
-                "m_SlotId": 0
+                "m_SlotId": 1
             }
         },
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "20d6ebc89b914b0c83d3f8b1fe771ce0"
+                    "m_Id": "347bc1c64428488085911aea9ecd6920"
                 },
-                "m_SlotId": 2
+                "m_SlotId": 0
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "c7e1f851e1914dfa83847404d6a66440"
+                    "m_Id": "860760b78617487e9d197a9b00f955ec"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "347bc1c64428488085911aea9ecd6920"
                 },
                 "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "cf248b5ee89947afa639605cec3508ee"
+                },
+                "m_SlotId": 1
             }
         },
         {
@@ -149,15 +170,29 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "423a85ed24744f1f8a7d32d7bbe4b985"
+                    "m_Id": "69ee95579277414b976cc4f92ccee9b9"
                 },
-                "m_SlotId": 1
+                "m_SlotId": 0
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "20687ec0ab1046e4b00ce3f68092cee5"
+                    "m_Id": "860760b78617487e9d197a9b00f955ec"
+                },
+                "m_SlotId": 3
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "69ee95579277414b976cc4f92ccee9b9"
                 },
                 "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "cf248b5ee89947afa639605cec3508ee"
+                },
+                "m_SlotId": 3
             }
         },
         {
@@ -172,6 +207,20 @@
                     "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
                 },
                 "m_SlotId": 4
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "860760b78617487e9d197a9b00f955ec"
+                },
+                "m_SlotId": 4
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "2b5cf5822378467c8ffa4e4037ea7b1f"
+                },
+                "m_SlotId": 1
             }
         },
         {
@@ -211,9 +260,51 @@
             },
             "m_InputSlot": {
                 "m_Node": {
+                    "m_Id": "860760b78617487e9d197a9b00f955ec"
+                },
+                "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "bd1450a953c049f0a08aab0a999ef74f"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "cf248b5ee89947afa639605cec3508ee"
+                },
+                "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "bd1450a953c049f0a08aab0a999ef74f"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
                     "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
                 },
                 "m_SlotId": 3
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "cf248b5ee89947afa639605cec3508ee"
+                },
+                "m_SlotId": 4
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "2b5cf5822378467c8ffa4e4037ea7b1f"
+                },
+                "m_SlotId": 4
             }
         },
         {
@@ -225,9 +316,9 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "20d6ebc89b914b0c83d3f8b1fe771ce0"
+                    "m_Id": "c7e1f851e1914dfa83847404d6a66440"
                 },
-                "m_SlotId": 1
+                "m_SlotId": 0
             }
         },
         {
@@ -239,9 +330,51 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "9ed9ea0c7fa74ceeb8197100c740251f"
+                    "m_Id": "2b5cf5822378467c8ffa4e4037ea7b1f"
                 },
-                "m_SlotId": 1
+                "m_SlotId": 3
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "f36957f8bb334884ae1c5cfd6aa3f78c"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "860760b78617487e9d197a9b00f955ec"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "f36957f8bb334884ae1c5cfd6aa3f78c"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "cf248b5ee89947afa639605cec3508ee"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "f36957f8bb334884ae1c5cfd6aa3f78c"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
+                },
+                "m_SlotId": 0
             }
         }
     ],
@@ -298,6 +431,45 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "037e0e2a62d94beba8ba93dc069b86ff",
+    "m_Id": 2,
+    "m_DisplayName": "CircleRadius",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "CircleRadius",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "042f3b72f2524c6e8dc46aab17d5dd14",
+    "m_Id": 1,
+    "m_DisplayName": "Shotgun",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "SHOTGUN",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "09bad5b2d1ec42ffa9cdba38b1021e40",
     "m_Id": 0,
@@ -307,7 +479,7 @@
     "m_ShaderOutputName": "Edge",
     "m_StageCapability": 3,
     "m_Value": {
-        "x": -0.019999999552965165,
+        "x": -0.05999999865889549,
         "y": 1.0,
         "z": 1.0,
         "w": 1.0
@@ -332,9 +504,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1074.4000244140625,
-            "y": -45.599998474121097,
-            "width": 208.0,
+            "x": -1440.8001708984375,
+            "y": -8.800009727478028,
+            "width": 208.0001220703125,
             "height": 325.6000061035156
         }
     },
@@ -384,78 +556,6 @@
         "y": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
-    "m_ObjectId": "173c16812a0a423ea9b3d3dd5a46c568",
-    "m_Id": 1,
-    "m_DisplayName": "B",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "B",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "e00": 2.0,
-        "e01": 2.0,
-        "e02": 2.0,
-        "e03": 2.0,
-        "e10": 2.0,
-        "e11": 2.0,
-        "e12": 2.0,
-        "e13": 2.0,
-        "e20": 2.0,
-        "e21": 2.0,
-        "e22": 2.0,
-        "e23": 2.0,
-        "e30": 2.0,
-        "e31": 2.0,
-        "e32": 2.0,
-        "e33": 2.0
-    },
-    "m_DefaultValue": {
-        "e00": 1.0,
-        "e01": 0.0,
-        "e02": 0.0,
-        "e03": 0.0,
-        "e10": 0.0,
-        "e11": 1.0,
-        "e12": 0.0,
-        "e13": 0.0,
-        "e20": 0.0,
-        "e21": 0.0,
-        "e22": 1.0,
-        "e23": 0.0,
-        "e30": 0.0,
-        "e31": 0.0,
-        "e32": 0.0,
-        "e33": 1.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "17c90dbcfd354fd48c3f21d2a425b180",
-    "m_Id": 1,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
 }
 
 {
@@ -595,10 +695,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -487.9999694824219,
-            "y": 707.9999389648438,
-            "width": 208.00003051757813,
-            "height": 301.5999755859375
+            "x": -228.0000457763672,
+            "y": 669.5999755859375,
+            "width": 208.00015258789063,
+            "height": 301.59991455078127
         }
     },
     "m_Slots": [
@@ -635,89 +735,6 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.OneMinusNode",
-    "m_ObjectId": "20687ec0ab1046e4b00ce3f68092cee5",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "One Minus",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -362.39996337890627,
-            "y": 60.800018310546878,
-            "width": 208.00001525878907,
-            "height": 277.5999755859375
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "8102d6745a2343aa95bc7b82c5b39302"
-        },
-        {
-            "m_Id": "17c90dbcfd354fd48c3f21d2a425b180"
-        }
-    ],
-    "synonyms": [
-        "complement",
-        "invert",
-        "opposite"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
-    "m_ObjectId": "20d6ebc89b914b0c83d3f8b1fe771ce0",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Multiply",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -130.3999481201172,
-            "y": 220.79998779296876,
-            "width": 130.40000915527345,
-            "height": 117.60000610351563
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "390891efa6144dca9590b2ecb0fc2e86"
-        },
-        {
-            "m_Id": "173c16812a0a423ea9b3d3dd5a46c568"
-        },
-        {
-            "m_Id": "a9432a81757e4977b91267e5610d5851"
-        }
-    ],
-    "synonyms": [
-        "multiplication",
-        "times",
-        "x"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": false,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    }
 }
 
 {
@@ -770,28 +787,95 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ScreenPositionMaterialSlot",
-    "m_ObjectId": "2809696838954d26ab5a3855fb4d161a",
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "2a89543734104082b12950e5b9cde784",
     "m_Id": 0,
-    "m_DisplayName": "UV",
+    "m_DisplayName": "A",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "UV",
+    "m_ShaderOutputName": "A",
     "m_StageCapability": 3,
     "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
     },
     "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.KeywordNode",
+    "m_ObjectId": "2b5cf5822378467c8ffa4e4037ea7b1f",
+    "m_Group": {
+        "m_Id": ""
     },
-    "m_Labels": [],
-    "m_ScreenSpaceType": 0
+    "m_Name": "Mode",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -573.6738891601563,
+            "y": 1056.0955810546875,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "64981434844e4c7e8a9dfdd945925e55"
+        },
+        {
+            "m_Id": "a882bb19e74045299ea8d1fd364be146"
+        },
+        {
+            "m_Id": "042f3b72f2524c6e8dc46aab17d5dd14"
+        },
+        {
+            "m_Id": "fffbf0a1a01b47c1aa24fb74af11cd4a"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Keyword": {
+        "m_Id": "4489a17b3bc344a483682eba4f780dee"
+    }
 }
 
 {
@@ -828,9 +912,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1021.5999755859375,
-            "y": 439.20001220703127,
-            "width": 127.20001220703125,
+            "x": -1232.800048828125,
+            "y": 451.20001220703127,
+            "width": 127.2000732421875,
             "height": 33.5999755859375
         }
     },
@@ -885,30 +969,30 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
-    "m_ObjectId": "390891efa6144dca9590b2ecb0fc2e86",
-    "m_Id": 0,
-    "m_DisplayName": "A",
+    "m_ObjectId": "402da96a00cb4e54bc2851b0b2c2c06d",
+    "m_Id": 1,
+    "m_DisplayName": "B",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "A",
+    "m_ShaderOutputName": "B",
     "m_StageCapability": 3,
     "m_Value": {
-        "e00": 0.0,
-        "e01": 0.0,
-        "e02": 0.0,
-        "e03": 0.0,
-        "e10": 0.0,
-        "e11": 0.0,
-        "e12": 0.0,
-        "e13": 0.0,
-        "e20": 0.0,
-        "e21": 0.0,
-        "e22": 0.0,
-        "e23": 0.0,
-        "e30": 0.0,
-        "e31": 0.0,
-        "e32": 0.0,
-        "e33": 0.0
+        "e00": 2.0,
+        "e01": 2.0,
+        "e02": 2.0,
+        "e03": 2.0,
+        "e10": 2.0,
+        "e11": 2.0,
+        "e12": 2.0,
+        "e13": 2.0,
+        "e20": 2.0,
+        "e21": 2.0,
+        "e22": 2.0,
+        "e23": 2.0,
+        "e30": 2.0,
+        "e31": 2.0,
+        "e32": 2.0,
+        "e33": 2.0
     },
     "m_DefaultValue": {
         "e00": 1.0,
@@ -931,41 +1015,59 @@
 }
 
 {
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.SceneColorNode",
-    "m_ObjectId": "423a85ed24744f1f8a7d32d7bbe4b985",
-    "m_Group": {
-        "m_Id": ""
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
+    "m_ObjectId": "4489a17b3bc344a483682eba4f780dee",
+    "m_Guid": {
+        "m_GuidSerialized": "a89fe6a0-4f31-426f-b250-e7fa74426439"
     },
-    "m_Name": "Scene Color",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -522.952880859375,
-            "y": 100.04317474365235,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
+    "m_Name": "Mode",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Mode",
+    "m_DefaultReferenceName": "_MODE",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_KeywordType": 1,
+    "m_KeywordDefinition": 1,
+    "m_KeywordScope": 0,
+    "m_KeywordStages": 2,
+    "m_Entries": [
         {
-            "m_Id": "2809696838954d26ab5a3855fb4d161a"
+            "id": 3,
+            "displayName": "Default",
+            "referenceName": "DEFAULT"
         },
         {
-            "m_Id": "c0cb15e674d74932893ca57f7c322df6"
+            "id": 1,
+            "displayName": "Shotgun",
+            "referenceName": "SHOTGUN"
+        },
+        {
+            "id": 4,
+            "displayName": "Hat",
+            "referenceName": "HAT"
         }
     ],
-    "synonyms": [
-        "screen buffer"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    }
+    "m_Value": 0,
+    "m_IsEditable": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "4f2de7a6f66a4325a75f29ee54652297",
+    "m_Id": 2,
+    "m_DisplayName": "CircleRadius",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "CircleRadius",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -1101,6 +1203,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "64981434844e4c7e8a9dfdd945925e55",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "69ee95579277414b976cc4f92ccee9b9",
     "m_Group": {
@@ -1206,6 +1332,27 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
+    "m_ObjectId": "76b66e98c1274e9ea0cd1051e90a0c72",
+    "m_Id": 0,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "7d37a15d571445acb8c4e83e1261250d",
     "m_Group": {
@@ -1262,26 +1409,138 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "8102d6745a2343aa95bc7b82c5b39302",
-    "m_Id": 0,
-    "m_DisplayName": "In",
-    "m_SlotType": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "83dbbea3d2ec444aa2337d8345a60026",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
     "m_Hidden": false,
-    "m_ShaderOutputName": "In",
+    "m_ShaderOutputName": "Out",
     "m_StageCapability": 3,
     "m_Value": {
-        "x": 1.0,
-        "y": 1.0,
-        "z": 1.0,
-        "w": 1.0
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.CustomFunctionNode",
+    "m_ObjectId": "860760b78617487e9d197a9b00f955ec",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "CrossHairShotgun (Custom Function)",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1008.0000610351563,
+            "y": 904.0,
+            "width": 259.2000732421875,
+            "height": 349.5999755859375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "8b4e527591c845fbb28a8734f6d0a011"
+        },
+        {
+            "m_Id": "ba8a6b7c38bb499786890348c34881bf"
+        },
+        {
+            "m_Id": "037e0e2a62d94beba8ba93dc069b86ff"
+        },
+        {
+            "m_Id": "e0e9a0909b22414bb4d2447fd290663c"
+        },
+        {
+            "m_Id": "b112e50e07c148c082ae6bdd4ff74c86"
+        }
+    ],
+    "synonyms": [
+        "code",
+        "HLSL"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SourceType": 0,
+    "m_FunctionName": "CrossHairShotgun",
+    "m_FunctionSource": "97b563266b995af4aac2a76b8bbf0ed8",
+    "m_FunctionBody": "Enter function body here..."
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
+    "m_ObjectId": "8b4e527591c845fbb28a8734f6d0a011",
+    "m_Id": 0,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
     },
     "m_DefaultValue": {
         "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
+        "y": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "9612f9e773f842e6881c84f52637d7d3",
+    "m_Id": 3,
+    "m_DisplayName": "HitMarkerRadius",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "HitMarkerRadius",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -1398,49 +1657,25 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
-    "m_ObjectId": "a9432a81757e4977b91267e5610d5851",
-    "m_Id": 2,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "a882bb19e74045299ea8d1fd364be146",
+    "m_Id": 3,
+    "m_DisplayName": "Default",
+    "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
+    "m_ShaderOutputName": "DEFAULT",
     "m_StageCapability": 3,
     "m_Value": {
-        "e00": 0.0,
-        "e01": 0.0,
-        "e02": 0.0,
-        "e03": 0.0,
-        "e10": 0.0,
-        "e11": 0.0,
-        "e12": 0.0,
-        "e13": 0.0,
-        "e20": 0.0,
-        "e21": 0.0,
-        "e22": 0.0,
-        "e23": 0.0,
-        "e30": 0.0,
-        "e31": 0.0,
-        "e32": 0.0,
-        "e33": 0.0
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     },
     "m_DefaultValue": {
-        "e00": 1.0,
-        "e01": 0.0,
-        "e02": 0.0,
-        "e03": 0.0,
-        "e10": 0.0,
-        "e11": 1.0,
-        "e12": 0.0,
-        "e13": 0.0,
-        "e20": 0.0,
-        "e21": 0.0,
-        "e22": 1.0,
-        "e23": 0.0,
-        "e30": 0.0,
-        "e31": 0.0,
-        "e32": 0.0,
-        "e33": 1.0
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     }
 }
 
@@ -1453,6 +1688,21 @@
     "m_SlotType": 0,
     "m_Hidden": false,
     "m_ShaderOutputName": "CircleRadius",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "b112e50e07c148c082ae6bdd4ff74c86",
+    "m_Id": 4,
+    "m_DisplayName": "Distance",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Distance",
     "m_StageCapability": 3,
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
@@ -1510,6 +1760,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "ba8a6b7c38bb499786890348c34881bf",
+    "m_Id": 1,
+    "m_DisplayName": "CrossSize",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "CrossSize",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "bbddf26580b945ed92ae67da5fc64c03",
     "m_Id": 1,
@@ -1541,10 +1806,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1315.199951171875,
-            "y": 524.7999877929688,
-            "width": 110.39990234375,
-            "height": 33.60003662109375
+            "x": -1288.0,
+            "y": 548.0,
+            "width": 110.4000244140625,
+            "height": 33.5999755859375
         }
     },
     "m_Slots": [
@@ -1582,6 +1847,9 @@
         },
         {
             "m_Id": "187b92def2fb4ca685fae44d6a779b0d"
+        },
+        {
+            "m_Id": "4489a17b3bc344a483682eba4f780dee"
         }
     ]
 }
@@ -1598,29 +1866,6 @@
     "m_StageCapability": 3,
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "c0cb15e674d74932893ca57f7c322df6",
-    "m_Id": 1,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
     "m_Labels": []
 }
 
@@ -1738,6 +1983,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "cc239467962b4234a4905a3508f04e75",
+    "m_Id": 4,
+    "m_DisplayName": "Distance",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Distance",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "ccd47f5c439346e7b6b8ab3341a6e73e",
     "m_Id": 1,
@@ -1758,6 +2018,58 @@
         "z": 0.0,
         "w": 0.0
     }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.CustomFunctionNode",
+    "m_ObjectId": "cf248b5ee89947afa639605cec3508ee",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "CrossHairHat (Custom Function)",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1036.800048828125,
+            "y": 1456.8001708984375,
+            "width": 259.2000732421875,
+            "height": 349.599853515625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "76b66e98c1274e9ea0cd1051e90a0c72"
+        },
+        {
+            "m_Id": "e8ceb9aff3c4469ba580ec2e70885cd3"
+        },
+        {
+            "m_Id": "4f2de7a6f66a4325a75f29ee54652297"
+        },
+        {
+            "m_Id": "9612f9e773f842e6881c84f52637d7d3"
+        },
+        {
+            "m_Id": "cc239467962b4234a4905a3508f04e75"
+        }
+    ],
+    "synonyms": [
+        "code",
+        "HLSL"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SourceType": 0,
+    "m_FunctionName": "CrossHairHat",
+    "m_FunctionSource": "5498a3c6282026f46b6d2de20b6bc801",
+    "m_FunctionBody": "Enter function body here..."
 }
 
 {
@@ -1806,6 +2118,21 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "e0e9a0909b22414bb4d2447fd290663c",
+    "m_Id": 3,
+    "m_DisplayName": "HitMarkerRadius",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "HitMarkerRadius",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "e2672f8b754c4d17a492c20e5fb36d03",
     "m_Id": 0,
     "m_DisplayName": "Alpha",
@@ -1815,6 +2142,21 @@
     "m_StageCapability": 2,
     "m_Value": 1.0,
     "m_DefaultValue": 1.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "e8ceb9aff3c4469ba580ec2e70885cd3",
+    "m_Id": 1,
+    "m_DisplayName": "CrossSize",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "CrossSize",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
     "m_Labels": []
 }
 
@@ -1830,9 +2172,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -318.3999328613281,
-            "y": 383.1999816894531,
-            "width": 207.99996948242188,
+            "x": -228.0,
+            "y": 246.39999389648438,
+            "width": 208.00001525878907,
             "height": 301.6000061035156
         }
     },
@@ -1869,9 +2211,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -794.4000854492188,
-            "y": 383.1999816894531,
-            "width": 232.0,
+            "x": -943.2000122070313,
+            "y": 484.7999572753906,
+            "width": 232.00006103515626,
             "height": 349.6000061035156
         }
     },
@@ -1931,5 +2273,72 @@
     },
     "m_Labels": [],
     "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
+    "m_ObjectId": "f36957f8bb334884ae1c5cfd6aa3f78c",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Multiply",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -846.8340454101563,
+            "y": 47.56589889526367,
+            "width": 208.0,
+            "height": 301.5999755859375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "2a89543734104082b12950e5b9cde784"
+        },
+        {
+            "m_Id": "402da96a00cb4e54bc2851b0b2c2c06d"
+        },
+        {
+            "m_Id": "83dbbea3d2ec444aa2337d8345a60026"
+        }
+    ],
+    "synonyms": [
+        "multiplication",
+        "times",
+        "x"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "fffbf0a1a01b47c1aa24fb74af11cd4a",
+    "m_Id": 4,
+    "m_DisplayName": "Hat",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "HAT",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 

--- a/Assets/Shaders/Crosshair.shadergraph
+++ b/Assets/Shaders/Crosshair.shadergraph
@@ -68,6 +68,9 @@
         },
         {
             "m_Id": "69ee95579277414b976cc4f92ccee9b9"
+        },
+        {
+            "m_Id": "1e6635b34dba4905bddc0eb0019d1e95"
         }
     ],
     "m_GroupDatas": [],
@@ -83,6 +86,20 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "1e6635b34dba4905bddc0eb0019d1e95"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "7d37a15d571445acb8c4e83e1261250d"
                 },
                 "m_SlotId": 0
             }
@@ -166,6 +183,20 @@
             },
             "m_InputSlot": {
                 "m_Node": {
+                    "m_Id": "1e6635b34dba4905bddc0eb0019d1e95"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "9ed9ea0c7fa74ceeb8197100c740251f"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
                     "m_Id": "e9d7b5b1ee724174a7ec292bdcd22c5e"
                 },
                 "m_SlotId": 1
@@ -202,20 +233,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "e9d7b5b1ee724174a7ec292bdcd22c5e"
-                },
-                "m_SlotId": 2
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "7d37a15d571445acb8c4e83e1261250d"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
                 },
                 "m_SlotId": 1
@@ -247,8 +264,8 @@
     },
     "m_FragmentContext": {
         "m_Position": {
-            "x": 0.0,
-            "y": 200.0
+            "x": 77.5999755859375,
+            "y": 196.00001525878907
         },
         "m_Blocks": [
             {
@@ -277,6 +294,30 @@
             "m_Id": "7fc333d745a84bbd9a1102b11d57db5a"
         }
     ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "09bad5b2d1ec42ffa9cdba38b1021e40",
+    "m_Id": 0,
+    "m_DisplayName": "Edge",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Edge",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": -0.019999999552965165,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -540,6 +581,45 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "VertexDescription.Normal"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.StepNode",
+    "m_ObjectId": "1e6635b34dba4905bddc0eb0019d1e95",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Step",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -487.9999694824219,
+            "y": 707.9999389648438,
+            "width": 208.00003051757813,
+            "height": 301.5999755859375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "09bad5b2d1ec42ffa9cdba38b1021e40"
+        },
+        {
+            "m_Id": "52d5a172a2da48aa9e27e01f754a910e"
+        },
+        {
+            "m_Id": "6d3522e1c35648bea74670a4d8a542a8"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -890,6 +970,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "52d5a172a2da48aa9e27e01f754a910e",
+    "m_Id": 1,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "54f4579aeb3341eaa6814ea8ecb66e6b",
     "m_Group": {
@@ -1028,6 +1132,30 @@
     },
     "m_Property": {
         "m_Id": "187b92def2fb4ca685fae44d6a779b0d"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "6d3522e1c35648bea74670a4d8a542a8",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     }
 }
 
@@ -1189,10 +1317,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -502.962646484375,
-            "y": 299.4373779296875,
-            "width": 208.0,
-            "height": 301.6000061035156
+            "x": -542.4000854492188,
+            "y": 338.3999938964844,
+            "width": 208.00006103515626,
+            "height": 301.5999450683594
         }
     },
     "m_Slots": [
@@ -1702,9 +1830,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -258.3999938964844,
-            "y": 449.6000061035156,
-            "width": 208.0,
+            "x": -318.3999328613281,
+            "y": 383.1999816894531,
+            "width": 207.99996948242188,
             "height": 301.6000061035156
         }
     },
@@ -1741,10 +1869,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -762.4000244140625,
-            "y": 384.0,
-            "width": 212.0,
-            "height": 301.5999755859375
+            "x": -794.4000854492188,
+            "y": 383.1999816894531,
+            "width": 232.0,
+            "height": 349.6000061035156
         }
     },
     "m_Slots": [

--- a/Assets/Shaders/Crosshair.shadergraph
+++ b/Assets/Shaders/Crosshair.shadergraph
@@ -11,6 +11,9 @@
         },
         {
             "m_Id": "39003c110ecc4efeb92e0a4f81adf62c"
+        },
+        {
+            "m_Id": "187b92def2fb4ca685fae44d6a779b0d"
         }
     ],
     "m_Keywords": [],
@@ -62,6 +65,9 @@
         },
         {
             "m_Id": "20d6ebc89b914b0c83d3f8b1fe771ce0"
+        },
+        {
+            "m_Id": "69ee95579277414b976cc4f92ccee9b9"
         }
     ],
     "m_GroupDatas": [],
@@ -135,6 +141,20 @@
                     "m_Id": "20687ec0ab1046e4b00ce3f68092cee5"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "69ee95579277414b976cc4f92ccee9b9"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "ef5bd6ae10c045938b52ca9c8926f784"
+                },
+                "m_SlotId": 4
             }
         },
         {
@@ -398,6 +418,49 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "187b92def2fb4ca685fae44d6a779b0d",
+    "m_Guid": {
+        "m_GuidSerialized": "6591cd6f-f50c-4106-ab48-fb325aae5d86"
+    },
+    "m_Name": "HitMarkerRadius",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "HitMarkerRadius",
+    "m_DefaultReferenceName": "_HitMarkerRadius",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "1884236d1166428caab304ddc7d5033f",
+    "m_Id": 4,
+    "m_DisplayName": "HitMarkerRadius",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "HitMarkerRadius",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "194a705046b64931a090f181ed7c4e88",
@@ -546,10 +609,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -258.3999938964844,
-            "y": 171.1999969482422,
-            "width": 208.0,
-            "height": 301.60003662109377
+            "x": -130.3999481201172,
+            "y": 220.79998779296876,
+            "width": 130.40000915527345,
+            "height": 117.60000610351563
         }
     },
     "m_Slots": [
@@ -569,7 +632,7 @@
         "x"
     ],
     "m_Precision": 0,
-    "m_PreviewExpanded": true,
+    "m_PreviewExpanded": false,
     "m_DismissedVersion": 0,
     "m_PreviewMode": 0,
     "m_CustomColors": {
@@ -929,6 +992,42 @@
     "m_RangeValues": {
         "x": 0.0,
         "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "69ee95579277414b976cc4f92ccee9b9",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1315.199951171875,
+            "y": 680.0,
+            "width": 162.39990234375,
+            "height": 33.60003662109375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "d6b4d29cc5614f9ea88c973e85d9c9b7"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "187b92def2fb4ca685fae44d6a779b0d"
     }
 }
 
@@ -1352,6 +1451,9 @@
         },
         {
             "m_Id": "39003c110ecc4efeb92e0a4f81adf62c"
+        },
+        {
+            "m_Id": "187b92def2fb4ca685fae44d6a779b0d"
         }
     ]
 }
@@ -1561,6 +1663,21 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "d6b4d29cc5614f9ea88c973e85d9c9b7",
+    "m_Id": 0,
+    "m_DisplayName": "HitMarkerRadius",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "e2672f8b754c4d17a492c20e5fb36d03",
     "m_Id": 0,
     "m_DisplayName": "Alpha",
@@ -1639,6 +1756,9 @@
         },
         {
             "m_Id": "a979b08289834e069512937ffd2faf6c"
+        },
+        {
+            "m_Id": "1884236d1166428caab304ddc7d5033f"
         },
         {
             "m_Id": "1fe619ab1c344729b4f4c7f0eb3fade3"

--- a/Assets/Shaders/Crosshair.shadergraph.meta
+++ b/Assets/Shaders/Crosshair.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 7e9b4ecd48e3c24449e0f28442b37d31
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}


### PR DESCRIPTION
- Crosshair with gunstats modifiable radius for the outline, and separate punch animation for only the cross.
- The crosshair now also has a black outline so it always has a nice contrast.
- Shotgun has a unique non-circular outline
- Hat-a-pult has a unique hat shaped outline
- Additional hitmarker when you deal damage (which is not always only bullet hit, this way we can differentiate between hits and fire procs)