### PR TITLE
Prevent nullreference in soda can sounds + misc other exceptionish fixes

### DIFF
--- a/Assets/Prefabs/Props/SodaCan.prefab
+++ b/Assets/Prefabs/Props/SodaCan.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 8128142972001420894}
   - component: {fileID: 3141625874019903605}
   - component: {fileID: 5842433434336445112}
+  - component: {fileID: 206634420414526630}
   m_Layer: 3
   m_Name: SodaCan
   m_TagString: Untagged
@@ -60,7 +61,6 @@ MonoBehaviour:
   timeSpentFlying: 10
   sprayEffect: {fileID: 443343156016952106}
   explosion: {fileID: 3590230029954673581}
-  audioSource: {fileID: 3179586820888703256}
   sprayNoise: {fileID: 11400000, guid: cb524168a86183940a86feab09f730d8, type: 2}
   mesh: {fileID: 2997704316376001849}
 --- !u!114 &5598940461500466729
@@ -189,7 +189,103 @@ MonoBehaviour:
   hitSounds: {fileID: 11400000, guid: a94abf38e18f286f2a0c314c7910b105, type: 2}
   criticalHitSounds: {fileID: 0}
   extraHitSounds: {fileID: 0}
-  audioSource: {fileID: 3179586820888703256}
+  audioSource: {fileID: 206634420414526630}
+--- !u!82 &206634420414526630
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 236491453487163102}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 4898656368289658944, guid: 92cf7610df7967a41806df0e74d33c49, type: 2}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 5
+  MinDistance: 3
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &2352115244237804060
 GameObject:
   m_ObjectHideFlags: 0
@@ -613,7 +709,7 @@ AudioSource:
   m_Enabled: 1
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 4898656368289658944, guid: 92cf7610df7967a41806df0e74d33c49, type: 2}
-  m_audioClip: {fileID: 8300000, guid: b6284216ae87a2813a7477ff5d4c4c7e, type: 3}
+  m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
   m_Volume: 1
   m_Pitch: 1

--- a/Assets/Scripts/Audio/HitSounds.cs
+++ b/Assets/Scripts/Audio/HitSounds.cs
@@ -31,6 +31,9 @@ public class HitSounds : MonoBehaviour
 
     private void OnDamageTaken(HealthController healthController, float damage, DamageInfo info)
     {
+        if (!audioSource)
+            return;
+
         if (criticalHitSounds && info.isCritical)
         {
             criticalHitSounds.Play(audioSource);

--- a/Assets/Scripts/Augment/GunController.cs
+++ b/Assets/Scripts/Augment/GunController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using Mirror;
 using UnityEngine;
@@ -179,10 +180,18 @@ public class GunController : NetworkBehaviour
     [ClientRpc]
     private void RpcFire(Quaternion rotation)
     {
-        onFireStart?.Invoke(stats);
-        projectile.projectileOutput = outputs[0];
-        projectile.projectileRotation = rotation;
-        ActuallyFire();
+        try
+        {
+            onFireStart?.Invoke(stats);
+            projectile.projectileOutput = outputs[0];
+            projectile.projectileRotation = rotation;
+            ActuallyFire();
+        }
+        catch (Exception e)
+        {
+            Debug.LogError("Failed to fire gun!");
+            Debug.LogError(e);
+        }
     }
 
     [Command]
@@ -194,7 +203,15 @@ public class GunController : NetworkBehaviour
     [ClientRpc]
     private void RpcFireWithNoAmmo()
     {
-        onFireNoAmmo?.Invoke(stats);
+        try
+        {
+            onFireNoAmmo?.Invoke(stats);
+        }
+        catch (Exception e)
+        {
+            Debug.LogError("Failed to fire gun w/o ammo!");
+            Debug.LogError(e);
+        }
     }
 
     private void FireGun()
@@ -211,7 +228,7 @@ public class GunController : NetworkBehaviour
             AimAtTarget();
             CmdFire(projectile.projectileRotation);
         }
-        catch (System.Exception e)
+        catch (Exception e)
         {
             // Hopefully recoverable error. Firing has had lots of bugs before,
             // hopefully we avoid displaying them in their gruesome nature to the user this way.

--- a/Assets/Scripts/Augment/GunController.cs
+++ b/Assets/Scripts/Augment/GunController.cs
@@ -177,7 +177,7 @@ public class GunController : NetworkBehaviour
         RpcFire(rotation);
     }
 
-    [ClientRpc]
+    [ClientRpc(includeOwner = false)]
     private void RpcFire(Quaternion rotation)
     {
         try
@@ -200,7 +200,7 @@ public class GunController : NetworkBehaviour
         RpcFireWithNoAmmo();
     }
 
-    [ClientRpc]
+    [ClientRpc(includeOwner = false)]
     private void RpcFireWithNoAmmo()
     {
         try
@@ -219,6 +219,8 @@ public class GunController : NetworkBehaviour
         if (stats.Ammo <= 0)
         {
             CmdFireWithNoAmmo();
+            // Handle this immediately yourself
+            onFireNoAmmo?.Invoke(stats);
             return;
         }
 
@@ -226,12 +228,16 @@ public class GunController : NetworkBehaviour
         {
             onFireStart?.Invoke(stats);
             AimAtTarget();
+            // Tell server to fire
             CmdFire(projectile.projectileRotation);
+            // but fire immediately yourself!
+            ActuallyFire();
         }
         catch (Exception e)
         {
             // Hopefully recoverable error. Firing has had lots of bugs before,
             // hopefully we avoid displaying them in their gruesome nature to the user this way.
+            Debug.LogError("Failed to fire gun on owner's client!");
             Debug.LogError(e);
         }
     }

--- a/Assets/Scripts/HealthController.cs
+++ b/Assets/Scripts/HealthController.cs
@@ -1,3 +1,4 @@
+using System;
 using Mirror;
 using UnityEngine;
 
@@ -40,18 +41,34 @@ public class HealthController : NetworkBehaviour
         }
         else if (isServer)
         {
-            Debug.Log($"Dealing {info.damage} from {info.sourcePlayer.identity.playerName} on server");
-            var networkInfo = new NetworkDamageInfo(info.sourcePlayer.id, info);
-            DealDamageRpc(networkInfo);
+            try
+            {
+                Debug.Log($"Dealing {info.damage} from {info.sourcePlayer.identity.playerName} on server");
+                var networkInfo = new NetworkDamageInfo(info.sourcePlayer.id, info);
+                DealDamageRpc(networkInfo);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Failed to deal damage from server!");
+                Debug.LogError(e);
+            }
         }
     }
 
     [ClientRpc]
     private void DealDamageRpc(NetworkDamageInfo networkInfo)
     {
-        var source = Peer2PeerTransport.PlayerInstanceByID[networkInfo.sourcePlayer];
-        var info = new DamageInfo(source, networkInfo);
-        ActuallyDealDamage(info);
+        try
+        {
+            var source = Peer2PeerTransport.PlayerInstanceByID[networkInfo.sourcePlayer];
+            var info = new DamageInfo(source, networkInfo);
+            ActuallyDealDamage(info);
+        }
+        catch (Exception e)
+        {
+            Debug.LogError("Failed to deal damage on client!");
+            Debug.LogError(e);
+        }
     }
 
     private void ActuallyDealDamage(DamageInfo info)

--- a/Assets/Scripts/Interactables/SodaCan.cs
+++ b/Assets/Scripts/Interactables/SodaCan.cs
@@ -9,6 +9,9 @@ enum SodaCanState
     Emptied,
 }
 
+[RequireComponent(typeof(AudioSource))]
+[RequireComponent(typeof(HealthController))]
+[RequireComponent(typeof(Rigidbody))]
 public class SodaCan : MonoBehaviour
 {
     [SerializeField]
@@ -29,7 +32,6 @@ public class SodaCan : MonoBehaviour
     [SerializeField]
     private ExplosionController explosion;
 
-    [SerializeField]
     private AudioSource audioSource;
 
     [SerializeField]
@@ -47,6 +49,7 @@ public class SodaCan : MonoBehaviour
 
     private void Start()
     {
+        audioSource = GetComponent<AudioSource>();
         body = GetComponent<Rigidbody>();
         healthController = GetComponent<HealthController>();
         healthController.onDeath += OnDeath;


### PR DESCRIPTION
What could happen here, with the soda can hit sounds using the explosion's audio source:

- Soda can explodes
- Explosion destroys itself
- Hitbox is shot/damaged again
- No audiosource!

Also fixes a bunch of semi-related issues.