### PR TITLE
Add sfx for bodies indicating they have no more ammo left

### DIFF
--- a/Assets/Audio/Augments/reloads/FireNoAmmoAuto.asset
+++ b/Assets/Audio/Augments/reloads/FireNoAmmoAuto.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa94d7cf98a253641a478b6ab78a05e3, type: 3}
+  m_Name: FireNoAmmoAuto
+  m_EditorClassIdentifier: 
+  sounds:
+  - {fileID: 8300000, guid: a5a4cf79a7503d34da12bd3969f9ddfe, type: 3}
+  semitoneRange:
+    min: -1
+    max: 1
+  continuousPitchBend: 0
+  volumeRange:
+    min: 1
+    max: 1
+  is3D: 0
+  shouldPlayInSplitscreen: 1

--- a/Assets/Audio/Augments/reloads/FireNoAmmoAuto.asset.meta
+++ b/Assets/Audio/Augments/reloads/FireNoAmmoAuto.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1aa375551f5f99a4f921f9cd8645073f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/Augments/reloads/FireNoAmmoBurst.asset
+++ b/Assets/Audio/Augments/reloads/FireNoAmmoBurst.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa94d7cf98a253641a478b6ab78a05e3, type: 3}
+  m_Name: FireNoAmmoBurst
+  m_EditorClassIdentifier: 
+  sounds:
+  - {fileID: 8300000, guid: cacd836afb9e3f643837bd6598f137b1, type: 3}
+  semitoneRange:
+    min: -1
+    max: 1
+  continuousPitchBend: 0
+  volumeRange:
+    min: 1
+    max: 1
+  is3D: 0
+  shouldPlayInSplitscreen: 1

--- a/Assets/Audio/Augments/reloads/FireNoAmmoBurst.asset.meta
+++ b/Assets/Audio/Augments/reloads/FireNoAmmoBurst.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 67c2cbbe3dcaef54ca6f0ac3f987ad8e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/UI/click2.mp3.meta
+++ b/Assets/Audio/UI/click2.mp3.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Prefabs/GunParts/DdrBody.prefab
+++ b/Assets/Prefabs/GunParts/DdrBody.prefab
@@ -109,6 +109,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 566bc67f0e4ffa14abca4206844dd2a5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
   stats: {fileID: 11400000, guid: 8d8ddad5278646149956827ea710b18e, type: 2}
   attachmentSite: {fileID: 4099967304580071091}
   midpoint: {fileID: 7990957487315684423}
@@ -141,6 +144,7 @@ MonoBehaviour:
     color: {r: 0, g: 0.5137255, b: 1, a: 1}
     awardFactor: 0.25
     audio: {fileID: 0}
+  noAmmo: {fileID: 11400000, guid: 67c2cbbe3dcaef54ca6f0ac3f987ad8e, type: 2}
 --- !u!82 &8367018402671598818
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/GunParts/LawnMowerBody.prefab
+++ b/Assets/Prefabs/GunParts/LawnMowerBody.prefab
@@ -214,6 +214,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8375e0b741c00094a839bd88e690adf5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
   stats: {fileID: 11400000, guid: ed4e735ad892c924f83cd52e7590ab02, type: 2}
   attachmentSite: {fileID: 4393314981897995506}
   midpoint: {fileID: 1670967186181035241}
@@ -235,6 +238,7 @@ MonoBehaviour:
   mowerScreenMaterialIndex: 1
   mowerScreen: {fileID: 2100000, guid: ba0e56975e31013409abfe9b36e7aa35, type: 2}
   plopSounds: {fileID: 11400000, guid: e3cc9c8a794f4f94bb6e134c61b5a645, type: 2}
+  noAmmo: {fileID: 11400000, guid: 67c2cbbe3dcaef54ca6f0ac3f987ad8e, type: 2}
 --- !u!95 &2789145164633129729
 Animator:
   serializedVersion: 5

--- a/Assets/Prefabs/GunParts/RevolverBody.prefab
+++ b/Assets/Prefabs/GunParts/RevolverBody.prefab
@@ -5369,6 +5369,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2f934f7d741a974b8c90b18eb8a7e79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
   stats: {fileID: 11400000, guid: ee2a4688da7e5cc3d81a023465de8dd5, type: 2}
   attachmentSite: {fileID: 1985392096533510068}
   midpoint: {fileID: 8979843661292602557}
@@ -5382,6 +5385,7 @@ MonoBehaviour:
   bonkWeak: {fileID: 11400000, guid: d7bc77e35e457f74a8ec062583ef335e, type: 2}
   bonkStrong: {fileID: 11400000, guid: 853a0ba196c8b5c4fb48ccc426a60990, type: 2}
   bulletDrop: {fileID: 11400000, guid: 6cb9aecceff300e4481c3c5b856f6217, type: 2}
+  noAmmo: {fileID: 11400000, guid: 67c2cbbe3dcaef54ca6f0ac3f987ad8e, type: 2}
 --- !u!95 &5886082362856684746
 Animator:
   serializedVersion: 5

--- a/Assets/Prefabs/GunParts/SeekerBody.prefab
+++ b/Assets/Prefabs/GunParts/SeekerBody.prefab
@@ -135,6 +135,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6091813380986844731}
   - component: {fileID: 5827192658648779728}
+  - component: {fileID: 7539655102485540665}
   m_Layer: 0
   m_Name: SeekerBody
   m_TagString: Untagged
@@ -175,6 +176,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eaebe3246f7ea744daec5c5f4b21add1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
   stats: {fileID: 11400000, guid: 8db82c5525856ff48bd577e07b302d95, type: 2}
   attachmentSite: {fileID: 8593661159712164428}
   midpoint: {fileID: 8367956633957259915}
@@ -186,6 +190,104 @@ MonoBehaviour:
   radarRotationSpeed: 5
   playerHandLeft: {fileID: 2010811563224460951}
   playerHandRight: {fileID: 1438169879683852442}
+  audioSource: {fileID: 7539655102485540665}
+  noAmmo: {fileID: 11400000, guid: 1aa375551f5f99a4f921f9cd8645073f, type: 2}
+--- !u!82 &7539655102485540665
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6472785782954257469}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 4898656368289658944, guid: 92cf7610df7967a41806df0e74d33c49, type: 2}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &7404903565536474900
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/GunParts/SodiePopperBody.prefab
+++ b/Assets/Prefabs/GunParts/SodiePopperBody.prefab
@@ -1094,6 +1094,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 014bec4865f87254f98a67df11d40951, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
   stats: {fileID: 11400000, guid: 6cf557fa85b73e942ab2e8e8ab3cbcc5, type: 2}
   attachmentSite: {fileID: 8523496319176683420}
   midpoint: {fileID: 7809023748073634624}
@@ -1112,6 +1115,7 @@ MonoBehaviour:
   anim: {fileID: 4713226990840197158}
   playerHandRight: {fileID: 3602634738544884281}
   slosh: {fileID: 11400000, guid: d73e3997e4e128148bed4179a5fc393d, type: 2}
+  noAmmo: {fileID: 11400000, guid: 1aa375551f5f99a4f921f9cd8645073f, type: 2}
 --- !u!95 &4713226990840197158
 Animator:
   serializedVersion: 5

--- a/Assets/Prefabs/GunParts/SolarBody.prefab
+++ b/Assets/Prefabs/GunParts/SolarBody.prefab
@@ -109,6 +109,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e32e1f9858ee6f447af65f7805644580, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
   stats: {fileID: 11400000, guid: 72992832157d0fb419710998773a0d05, type: 2}
   attachmentSite: {fileID: 5853084310418703454}
   midpoint: {fileID: 6250885166725746227}
@@ -125,6 +128,7 @@ MonoBehaviour:
   reloadEfficiencyPercentagen: 0.25
   chargeUp: {fileID: 11400000, guid: 76631c2fa554819409c442c49bf2ef52, type: 2}
   chargeDown: {fileID: 11400000, guid: 4eeddff2ba2a9854ba0e05356f0867b7, type: 2}
+  noAmmo: {fileID: 11400000, guid: 1aa375551f5f99a4f921f9cd8645073f, type: 2}
 --- !u!82 &2416882217755949969
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Augment/AugmentImplementations/AmmoBoxBody.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/AmmoBoxBody.cs
@@ -14,6 +14,10 @@ public class AmmoBoxBody : GunBody
     private PlayerHand playerHandLeft;
     [SerializeField]
     private PlayerHand playerHandRight;
+    [SerializeField]
+    private AudioSource audioSource;
+    [SerializeField]
+    private AudioGroup noAmmo;
 
     public override void Start()
     {
@@ -28,6 +32,7 @@ public class AmmoBoxBody : GunBody
         playerHandRight.gameObject.SetActive(true);
         playerHandLeft.SetPlayer(gunController.Player);
         playerHandLeft.gameObject.SetActive(true);
+        gunController.onFireNoAmmo += NoAmmoAudio;
     }
 
     private void OnDestroy()
@@ -35,6 +40,12 @@ public class AmmoBoxBody : GunBody
         if (!gunController)
             return;
         gunController.onFireStart -= Reload;
+        gunController.onFireNoAmmo -= NoAmmoAudio;
+    }
+
+    private void NoAmmoAudio(GunStats _)
+    {
+        noAmmo.Play(audioSource);
     }
 
     private IEnumerator SetClosestAmmoBox()

--- a/Assets/Scripts/Augment/AugmentImplementations/DDRBody.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/DDRBody.cs
@@ -60,6 +60,8 @@ public class DDRBody : GunBody
     private float musicPace;
 
     private AudioSource audioSource;
+    [SerializeField]
+    private AudioGroup noAmmo;
 
     public override void Start()
     {
@@ -103,6 +105,7 @@ public class DDRBody : GunBody
             playerHandRight.gameObject.SetActive(true);
 
             audioSource = GetComponent<AudioSource>();
+            gunController.onFireNoAmmo += NoAmmoAudio;
         }
 
     }
@@ -147,6 +150,11 @@ public class DDRBody : GunBody
     private void Fire(InputAction.CallbackContext ctx)
     {
         animator.OnFire(gunController.stats);
+    }
+
+    private void NoAmmoAudio(GunStats _)
+    {
+        noAmmo.Play(audioSource);
     }
 
     private void ArrowSelect(InputAction.CallbackContext ctx)
@@ -229,5 +237,6 @@ public class DDRBody : GunBody
 
         gunController.Player.inputManager.onFirePerformed -= Fire;
         gunController.Player.inputManager.onMovePerformed -= ArrowSelect;
+        gunController.onFireNoAmmo -= NoAmmoAudio;
     }
 }

--- a/Assets/Scripts/Augment/AugmentImplementations/LawnMower.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/LawnMower.cs
@@ -46,6 +46,8 @@ public class LawnMower : GunBody
     private AudioSource audioSource;
     [SerializeField]
     private AudioGroup plopSounds;
+    [SerializeField]
+    private AudioGroup noAmmo;
 
     public override void Start()
     {
@@ -70,6 +72,7 @@ public class LawnMower : GunBody
         handAnimator = GetComponent<Animator>();
         LineHoldingPoint = playerHandLeft.HoldingPoint;
         handString.gameObject.SetActive(true);
+        gunController.onFireNoAmmo += NoAmmoAudio;
 
         if (gunController.Player.GunOrigin.TryGetComponent(out GunController gunControllerDisplay))
             gunControllerDisplay.GetComponentInChildren<LawnMower>().LineHoldingPoint = gunController.Player.PlayerIK.LeftHandIKTransform;
@@ -79,6 +82,11 @@ public class LawnMower : GunBody
     {
         if (MatchController.Singleton)
             MatchController.Singleton.onRoundEnd -= DisableLine;
+        if (!gunController)
+            return;
+        gunController.onFireStart -= Fire;
+        gunController.onFireEnd -= FireEnd;
+        gunController.onFireNoAmmo += NoAmmoAudio;
     }
 
     private void LateUpdate()
@@ -125,6 +133,11 @@ public class LawnMower : GunBody
     private void FireEnd(GunStats stats)
     {
         if (success) Reload(stats);
+    }
+
+    private void NoAmmoAudio(GunStats _)
+    {
+        noAmmo.Play(audioSource);
     }
 
     protected override void Reload(GunStats stats)

--- a/Assets/Scripts/Augment/AugmentImplementations/Revolver.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Revolver.cs
@@ -17,6 +17,8 @@ public class Revolver : GunBody
     private AudioGroup bonkStrong;
     [SerializeField]
     private AudioGroup bulletDrop;
+    [SerializeField]
+    private AudioGroup noAmmo;
 
     private GunBarrel barrel;
     private GunExtension extension;
@@ -34,6 +36,7 @@ public class Revolver : GunBody
         playerHandLeft.SetPlayer(gunController.Player);
         playerHandRight.SetPlayer(gunController.Player);
         playerHandRight.gameObject.SetActive(true);
+        gunController.onFireNoAmmo += NoAmmoAudio;
     }
 
     protected override void Reload(GunStats stats)
@@ -57,6 +60,11 @@ public class Revolver : GunBody
     public void TriggerSteam()
     {
         steamParticles.Play();
+    }
+
+    private void NoAmmoAudio(GunStats _)
+    {
+        noAmmo.Play(audioSource);
     }
 
     public void PlayWeakBonk()
@@ -92,6 +100,14 @@ public class Revolver : GunBody
         if (extension)
             extension.transform.SetParent(gunController.transform, true);
         gunController.Reload(reloadEfficiencyPercentage);
+    }
+
+    private void OnDestroy()
+    {
+        if (!gunController)
+            return;
+        gunController.onFireEnd -= Reload;
+        gunController.onFireNoAmmo -= NoAmmoAudio;
     }
 
 }

--- a/Assets/Scripts/Augment/AugmentImplementations/RopeBody.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/RopeBody.cs
@@ -340,6 +340,9 @@ public class RopeBody : GunBody
             return;
         plugAnchor.Health.onDeath -= RemoveRope;
         Destroy(plugAnchor);
+        if (!gunController)
+            return;
+        gunController.onFireNoAmmo -= TryThrowPlug;
     }
 
 }

--- a/Assets/Scripts/Augment/AugmentImplementations/Solar/SolarBody.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Solar/SolarBody.cs
@@ -38,6 +38,8 @@ public class SolarBody : GunBody
     private AudioGroup chargeUp;
     [SerializeField]
     private AudioGroup chargeDown;
+    [SerializeField]
+    private AudioGroup noAmmo;
 
     public override void Start()
     {
@@ -57,6 +59,7 @@ public class SolarBody : GunBody
         playerHandLeft.SetPlayer(gunController.Player);
         playerHandLeft.gameObject.SetActive(true);
         audioSource = GetComponent<AudioSource>();
+        gunController.onFireNoAmmo += NoAmmoAudio;
     }
 
 
@@ -89,6 +92,11 @@ public class SolarBody : GunBody
         solarPanelMaterial.SetFloat("_EmissionStrength", strength);
     }
 
+    private void NoAmmoAudio(GunStats _)
+    {
+        noAmmo.Play(audioSource);
+    }
+
     private void FixedUpdate()
     {
         if (!gunController)
@@ -107,5 +115,12 @@ public class SolarBody : GunBody
             SetEmissionStrength(0);
             solarPanelMaterial.SetFloat("_On", 0);
         }
+    }
+
+    private void OnDestroy()
+    {
+        if (!gunController)
+            return;
+        gunController.onFireNoAmmo -= NoAmmoAudio;
     }
 }

--- a/Assets/SodiePopper.cs
+++ b/Assets/SodiePopper.cs
@@ -53,6 +53,8 @@ public class SodiePopper : GunBody
 
     [SerializeField]
     private AudioGroup slosh;
+    [SerializeField]
+    private AudioGroup noAmmo;
     public override void Start()
     {
         gunController = transform.parent?.GetComponent<GunController>();
@@ -69,6 +71,12 @@ public class SodiePopper : GunBody
         playerBody = gunController.Player.GetComponent<PlayerMovement>().Body;
         playerHandRight.SetPlayer(gunController.Player);
         playerHandRight.gameObject.SetActive(true);
+        gunController.onFireNoAmmo += NoAmmoAudio;
+    }
+
+    private void NoAmmoAudio(GunStats _)
+    {
+        noAmmo.Play(audioSource);
     }
 
     private void Update()
@@ -110,5 +118,12 @@ public class SodiePopper : GunBody
             lastPlayerDiff = playerDiff;
         }
         offsetTarget.position = lastPos;
+    }
+
+    private void OnDestroy()
+    {
+        if (!gunController)
+            return;
+        gunController.onFireNoAmmo -= NoAmmoAudio;
     }
 }


### PR DESCRIPTION
Some nice extra feedback and a cue for players to understand that they have no ammo left.
The sfx is dependant on body, usually tied to firing mode and only where it makes sense to have this (not tether)

Also fixed a couple of missing desubscriptions for body delegates