### PR TITLE
Avoid rendering the entire scene twice each frame

### DIFF
--- a/Assets/Scripts/Control&Input/OrbitCamera.cs
+++ b/Assets/Scripts/Control&Input/OrbitCamera.cs
@@ -95,8 +95,16 @@ public class OrbitCamera : MonoBehaviour
     {
         if (!cameraTransform || !input || MatchController.Singleton.IsShowingScoreboards)
             return;
-        isTracking = true;
+
         camera.enabled = true;
+        // Improves perf loss when playing splitscreen
+        var allPlayerCamerasAreDisabled = MatchController.Singleton.Players
+            .Where(p => p.inputManager != null)
+            .All(p => p.inputManager.PlayerCamera.enabled);
+        if (allPlayerCamerasAreDisabled)
+            MatchController.Singleton.ArenaCamera.enabled = false;
+
+        isTracking = true;
         target = nextTarget.AiAimSpot;
         if (nextTarget != player)
             player.HUDController.DisplaySpectatorScreen(nextTarget.identity);
@@ -106,6 +114,7 @@ public class OrbitCamera : MonoBehaviour
     {
         if (!camera)
             return;
+        MatchController.Singleton.ArenaCamera.enabled = true;
         isTracking = false;
         camera.enabled = false;
         ResetCamera();

--- a/Assets/Scripts/Gamestate/MatchController.cs
+++ b/Assets/Scripts/Gamestate/MatchController.cs
@@ -72,6 +72,9 @@ public class MatchController : NetworkBehaviour
     private bool isShowingScoreboards = false;
     public bool IsShowingScoreboards => isShowingScoreboards;
 
+    private Camera arenaCamera;
+    public Camera ArenaCamera => arenaCamera;
+
 
     private void Awake()
     {
@@ -104,6 +107,8 @@ public class MatchController : NetworkBehaviour
         }
 
         currentMapName ??= SceneManager.GetActiveScene().name;
+
+        arenaCamera = FindObjectsOfType<Camera>().FirstOrDefault(x => x.CompareTag("MainCamera"));
 
         var mainLight = GameObject.FindGameObjectsWithTag("MainLight")[0];
         RenderSettings.skybox.SetVector("_SunDirection", mainLight.transform.forward);
@@ -231,6 +236,12 @@ public class MatchController : NetworkBehaviour
     {
         // Delay first so we can see who killed who
         yield return new WaitForSeconds(delayBeforeRoundResults);
+
+        // Ensure arena camera is the only one that is enabled now!
+        foreach (var p in players.Where(p => p.inputManager != null))
+            p.inputManager.PlayerCamera.enabled = false;
+        arenaCamera.enabled = true;
+
         isShowingScoreboards = true;
         // Scoreboard subscribes here
         onRoundEnd?.Invoke();
@@ -313,7 +324,7 @@ public class MatchController : NetworkBehaviour
         foreach (var loser in loserModels.Zip(loserColors, (model, color) => (model, color)))
             loser.model.GetComponentInChildren<SkinnedMeshRenderer>().material.color = loser.color;
 
-        Camera.main.GetComponent<ArenaCamera>().PlayVictoryAnimation(winner);
+        arenaCamera.GetComponent<ArenaCamera>().PlayVictoryAnimation(winner);
     }
 
     public void WaitAndRestartAfterWinScreen()

--- a/Assets/Scripts/Gamestate/PlayerManager.cs
+++ b/Assets/Scripts/Gamestate/PlayerManager.cs
@@ -258,6 +258,10 @@ public class PlayerManager : NetworkBehaviour
             canvas.worldCamera = inputManager.GetComponentInChildren<Camera>();
             canvas.planeDistance = 0.21f;
             identity.onChipChange += hudController.OnChipChange;
+
+            // Disable arena camera so we don't render the entire scene twice
+            if (Camera.main)
+                Camera.main.enabled = false;
         }
 
         if (playerIK.TryGetComponent<BiddingPlayer>(out var biddingPlayer))

--- a/Assets/Scripts/Scoreboard/ScoreboardManager.cs
+++ b/Assets/Scripts/Scoreboard/ScoreboardManager.cs
@@ -103,7 +103,8 @@ public class ScoreboardManager : MonoBehaviour
     public IEnumerator ShowMatchResults()
     {
         // Animate the after battle scene
-        Camera.main.GetComponent<ArenaCamera>().PlayScoreboardAnimation();
+        var arenaCamera = MatchController.Singleton.ArenaCamera;
+        arenaCamera.GetComponent<ArenaCamera>().PlayScoreboardAnimation();
 
         for (int i = 0; i < scoreboards.Count; i++)
         {
@@ -113,7 +114,7 @@ public class ScoreboardManager : MonoBehaviour
         }
 
         // Do not start adding crimes before the camera has finished the animation
-        int delay = Mathf.RoundToInt(Camera.main.GetComponent<Animator>().runtimeAnimatorController.animationClips[0].length);
+        int delay = Mathf.RoundToInt(arenaCamera.GetComponent<Animator>().runtimeAnimatorController.animationClips[0].length);
         yield return new WaitForSeconds(delay);
 
         maxSteps = MaxNumberOfCrimes();


### PR DESCRIPTION
The overview camera has been enabled in the background and caused double rendering load *this entire time*. These changes should fix the problem, but some hiccups will still happen when playing in splitscreen and switching to the overview camera after one player is dead.

Closes #908