### PR TITLE
Fix detonate exceptions from async server calls with pooling

### DIFF
--- a/Assets/Scripts/Augment/AugmentImplementations/DynamiteBarrel.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/DynamiteBarrel.cs
@@ -1,4 +1,5 @@
 using Mirror;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -87,26 +88,34 @@ public class DynamiteBarrel : GunBarrel
     [ClientRpc]
     private void RpcDetonate()
     {
-        if (isDetonatableEarly)
+        try
         {
-            var explosivePositions = meshProjectiles.ProjectilePositions;
-            explosivePositions.ToList().ForEach(position =>
+            if (isDetonatableEarly)
+            {
+                var explosivePositions = meshProjectiles.ProjectilePositions;
+                explosivePositions.ToList().ForEach(position =>
                 {
                     var dynamite = (StickyDynamite)stickyModifer.InstantiateManual(position);
                     dynamite.Explosion.Init();
                     activeDynamites.Add(dynamite);
                 });
-            meshProjectiles.ClearProjectiles();
+                meshProjectiles.ClearProjectiles();
+            }
+            else if (sateliteUplink)
+                sateliteUplink.TargetManual(activeDynamites
+                    .Select(dynamite => dynamite.transform.position));
+
+            if (authority && activeDynamites.Count > 0 && gunController.Player.HUDController)
+                gunController.Player.HUDController.CrossHairDetonationAnimation();
+
+            activeDynamites.ForEach(dynamite => dynamite.Detonate(gunController.Player));
+            activeDynamites.Clear();
         }
-        else if (sateliteUplink)
-            sateliteUplink.TargetManual(activeDynamites
-                .Select(dynamite => dynamite.transform.position));
-
-        if (authority && activeDynamites.Count > 0 && gunController.Player.HUDController)
-            gunController.Player.HUDController.CrossHairDetonationAnimation();
-
-        activeDynamites.ForEach(dynamite => dynamite.Detonate(gunController.Player));
-        activeDynamites.Clear();
+        catch (Exception e)
+        {
+            Debug.LogError("Failed to detonate!");
+            Debug.LogError(e);
+        }
     }
 
     private void OnDeath(PlayerManager killer, PlayerManager victim, DamageInfo info)

--- a/Assets/Scripts/Augment/AugmentImplementations/StickyDynamite.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/StickyDynamite.cs
@@ -44,10 +44,18 @@ public class StickyDynamite : StuckObject
 
     public void Detonate(PlayerManager sourcePlayer)
     {
-        mesh.enabled = false;
-        explosiveBarrel.enabled = false;
-        smoke.enabled = false;
-        barrelSmoke.ToList().ForEach(smoke => smoke.enabled = false);
+        // Needs extra if-guards in case resetdynamite is called asynchronously by server
+        if (mesh)
+            mesh.enabled = false;
+        if (explosiveBarrel)
+            explosiveBarrel.enabled = false;
+        if(smoke)
+            smoke.enabled = false;
+        barrelSmoke.ToList().ForEach(smoke =>
+            {
+                if (smoke)
+                    smoke.enabled = false;
+            });
         // Double check that dynamite hasn't been taken by the pool before exploding
         if (explosion.gameObject.activeSelf)
         {


### PR DESCRIPTION
A bug report seemed to indicate null pointer exceptions when detonating and toggling renderers. This can be caused by dynamites being pooled while recieving an asynchronous detonate call. To mitigate this, if guards have been introduced when toggling from the detonate call.

A try catch block has also been added, as to mitigate the consequences of similar issues in the future, as has been done for RPCFire in GunController for the same reasons. 