### PR TITLE
Fix telescope sight persisting after death in spectator mode

### DIFF
--- a/Assets/Scripts/Augment/AugmentImplementations/Telescope.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Telescope.cs
@@ -46,11 +46,20 @@ public class Telescope : GunExtension
         gunController.Player.inputManager.onZoomPerformed += OnZoom;
         gunController.Player.inputManager.onZoomCanceled += OnZoomCanceled;
 
+        gunController.Player.onDeath += DesubscribeZoom;
+
         gunMeshes = gunController.GetComponentsInChildren<MeshRenderer>().ToList();
         gunSkinMeshes = gunController.GetComponentsInChildren<SkinnedMeshRenderer>().ToList();
 
         if (MatchController.Singleton)
             MatchController.Singleton.onRoundEnd += CancelZoom;
+    }
+
+    private void DesubscribeZoom(PlayerManager killer, PlayerManager victim, DamageInfo info)
+    {
+        gunController.Player.inputManager.onZoomPerformed -= OnZoom;
+        gunController.Player.inputManager.onZoomCanceled -= OnZoomCanceled;
+        CancelZoom();
     }
 
     private void OnZoom(InputAction.CallbackContext ctx)


### PR DESCRIPTION
Fix for reported issue where spectator text would be scrambled on zooming in spectator mode if the player was using the telescope. 