### PR TITLE
Fix loadingscreen transition flicker at start of animation

### DIFF
--- a/Assets/Scripts/LoadingScreen.cs
+++ b/Assets/Scripts/LoadingScreen.cs
@@ -112,6 +112,8 @@ public class LoadingScreen : MonoBehaviour
     private void SetTransition(Camera transitionCamera, bool isShow)
     {
         var transition = transform.GetChild(1).gameObject;
+        var slideMaterial = transition.GetComponent<Image>().material;
+        slideMaterial.SetFloat("_Coverage", -0.5f);
         transition.SetActive(true);
         if (!isShow)
             transform.GetChild(0).gameObject.SetActive(false);
@@ -119,7 +121,6 @@ public class LoadingScreen : MonoBehaviour
         transitionScreen.worldCamera = transitionCamera;
         transitionScreen.planeDistance = 1;
 
-        var slideMaterial = transition.GetComponent<Image>().material;
         slideMaterial.SetFloat("_Direction", isShow ? 1f : 0f);
 
         if (isShow)


### PR DESCRIPTION
Started noticing a very annoying flicker at the start of the loading screen transition animation.
This was due to the transition starting at the finished animation state the fram it was set active, now it always is enabled with the the correct first frame.