### PR TITLE
Fix dynamite barrel crashing the game with too many particles

### DIFF
--- a/Assets/Prefabs/GunParts/DynamiteBarrel.prefab
+++ b/Assets/Prefabs/GunParts/DynamiteBarrel.prefab
@@ -250,7 +250,7 @@ MonoBehaviour:
   stuckObject: {fileID: 1164456291252445790, guid: 2eb9af49dc0f4124a8d06d0a77c5b22c, type: 3}
   isDespawnedAfterTime: 0
   stuckLifeTime: 5
-  maxObjects: 20
+  maxObjects: 10
   triggerOnHit: 0
   onHitInterval: 1
   affectedLayers:

--- a/Assets/Scripts/Augment/AugmentImplementations/DynamiteBarrel.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/DynamiteBarrel.cs
@@ -18,7 +18,9 @@ public class DynamiteBarrel : GunBarrel
     [SerializeField]
     private MeshProjectileController meshProjectiles;
     private SateliteUplink sateliteUplink;
-
+    // Avoids crashing game with too many particle spawners in the case of sticky + in air
+    // TODO: allow for even more by instantiating particles with a positionbuffer instead
+    private const int maxDetonatableInTotal = 10;
 
     void Start()
     {
@@ -93,12 +95,13 @@ public class DynamiteBarrel : GunBarrel
             if (isDetonatableEarly)
             {
                 var explosivePositions = meshProjectiles.ProjectilePositions;
-                explosivePositions.ToList().ForEach(position =>
-                {
-                    var dynamite = (StickyDynamite)stickyModifer.InstantiateManual(position);
-                    dynamite.Explosion.Init();
-                    activeDynamites.Add(dynamite);
-                });
+                explosivePositions.Take(Mathf.Max(maxDetonatableInTotal - activeDynamites.Count, 0))
+                    .ToList().ForEach(position =>
+                    {
+                        var dynamite = (StickyDynamite)stickyModifer.InstantiateManual(position);
+                        dynamite.Explosion.Init();
+                        activeDynamites.Add(dynamite);
+                    });
                 meshProjectiles.ClearProjectiles();
             }
             else if (sateliteUplink)


### PR DESCRIPTION
Dynamite barrel can no longer get around the max dynamite amount by combining dynamites on the ground with dynamites in the air.  