### PR TITLE
Add debug logs that may prevent a certain crash

### DIFF
--- a/Assets/Scripts/Control&Input/RPRNetworkManager.cs
+++ b/Assets/Scripts/Control&Input/RPRNetworkManager.cs
@@ -888,6 +888,8 @@ public class RPRNetworkManager : NetworkManager
 
         playerManager.ApplyIdentity();
 
+        Debug.Log($"Finished initializing player {playerDetails.id}");
+
         // This ensures that behaviours on the gun have identities.
         // SHOULD be safe to initialize them here as this is at roughly the same point on all clients
         player.GetComponent<NetworkIdentity>().InitializeNetworkBehaviours();
@@ -898,6 +900,8 @@ public class RPRNetworkManager : NetworkManager
         }
 
         playerInstances[player.id] = player;
+
+        Debug.Log($"Finished registering player {playerDetails.id}");
     }
 
     #endregion


### PR DESCRIPTION
This may happen because logging increases the time it takes before the players are considered ready and input can be registered and funneled into Command calls. Or I may have gotten lucky while testing. Who knows.