### PR TITLE
Skips the auction animation after the first round.

### DIFF
--- a/Assets/Animation/BiddingScene/BiddingCamera.controller
+++ b/Assets/Animation/BiddingScene/BiddingCamera.controller
@@ -1,5 +1,32 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-8243948935160836185
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: EmptyState
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 9110991799194977466}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &-5057858892799018177
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -7,10 +34,7 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: start
-    m_EventTreshold: 0
+  m_Conditions: []
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1672963590970227041}
   m_Solo: 0
@@ -20,7 +44,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0.25
   m_TransitionOffset: 0
   m_ExitTime: 0.75
-  m_HasExitTime: 0
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -39,7 +63,7 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -94,16 +118,19 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: 1672963590970227041}
     m_Position: {x: 280, y: -20, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -8243948935160836185}
+    m_Position: {x: 230, y: 170, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 50, y: 20, z: 0}
-  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_EntryPosition: {x: 40, y: 120, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 3427284471098272652}
+  m_DefaultState: {fileID: -8243948935160836185}
 --- !u!1102 &3427284471098272652
 AnimatorState:
   serializedVersion: 6
@@ -131,3 +158,28 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &9110991799194977466
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: start
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3427284471098272652}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1

--- a/Assets/Scripts/Auction/AuctionDriver.cs
+++ b/Assets/Scripts/Auction/AuctionDriver.cs
@@ -125,8 +125,11 @@ public class AuctionDriver : NetworkBehaviour
 
     private IEnumerator WaitAndStartCameraAnimation()
     {
-        yield return new WaitForSeconds(biddingBeginDelay);
-        cameraAnimator.SetTrigger("start");
+        if (MatchController.Singleton.RoundCount == 1)
+        {
+            cameraAnimator.SetTrigger("start");
+            yield return new WaitForSeconds(biddingBeginDelay);
+        }
         hasAuctionStarted = true;
     }
 
@@ -254,7 +257,8 @@ public class AuctionDriver : NetworkBehaviour
 
     private IEnumerator PopulatePlatforms()
     {
-        yield return new WaitForSeconds(biddingBeginDelay);
+        if (MatchController.Singleton.RoundCount == 1)
+            yield return new WaitForSeconds(biddingBeginDelay);
 
         lastExtendedAuction = biddingPlatforms[0];
         lastExtendedAuction.onBiddingEnd += EndAuction;


### PR DESCRIPTION
Implemented by adding an initial empty state to the BiddingCamera and only triggering the animation based on the matchcontroller's RoundCount value

closes #974 