### PR TITLE
Prevent items that all players already own to appear in auctions.

### DIFF
--- a/Assets/ScriptableObjects/Items/AuctionStages/BodiesWeighted.asset
+++ b/Assets/ScriptableObjects/Items/AuctionStages/BodiesWeighted.asset
@@ -14,9 +14,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   stageDuration: 30
   items:
+  - {fileID: 11400000, guid: 77e9d94b7043eb348b2a0b25ae2cc56e, type: 2}
+  - {fileID: 11400000, guid: a99e4b806f963ac45a0635c34182107a, type: 2}
+  - {fileID: 11400000, guid: bdea3807a64796f4da3038c849234215, type: 2}
+  - {fileID: 11400000, guid: 63bf1979c291d114b8dfb8d01bb407a9, type: 2}
   - {fileID: 11400000, guid: 35edad6203bf79b478c8ee2e0f4479f3, type: 2}
-  - {fileID: 11400000, guid: 77e9d94b7043eb348b2a0b25ae2cc56e, type: 2}
-  - {fileID: 11400000, guid: 77e9d94b7043eb348b2a0b25ae2cc56e, type: 2}
+  - {fileID: 11400000, guid: 0abfdcb5f304f2647b378f82907d538c, type: 2}
   numItems: 3
   withReplacement: 0
   rates: []

--- a/Assets/Scripts/Auction/AuctionDriver.cs
+++ b/Assets/Scripts/Auction/AuctionDriver.cs
@@ -260,8 +260,16 @@ public class AuctionDriver : NetworkBehaviour
         lastExtendedAuction.onBiddingEnd += EndAuction;
 
         List<BiddingRound> biddingRounds = new List<BiddingRound>();
+
+        List<Item> ownedItems = new List<Item>();
+        foreach(PlayerManager pm in FindObjectsOfType<PlayerManager>())
+        {
+            ownedItems = ownedItems.Union(pm.identity.AllItems()).ToList();
+        }
+
         for (int i = 0; i < availableAuctionStages.Length; i++)
         {
+            availableAuctionStages[i].SetOwnedItems(ownedItems.ToArray());
             availableAuctionStages[i].Promote(out BiddingRound biddingRound);
             biddingRounds.Add(biddingRound);
         }

--- a/Assets/Scripts/Auction/AuctionStage.cs
+++ b/Assets/Scripts/Auction/AuctionStage.cs
@@ -7,6 +7,7 @@ public class AuctionStage : ScriptableObject
     protected float stageDuration = 15;
     [SerializeField]
     protected Item[] items;
+    protected Item[] ownedItems;
 
     /// <summary>
     /// This method should ONLY be called by staticInfo.
@@ -17,6 +18,10 @@ public class AuctionStage : ScriptableObject
         this.items = items;
     }
 
+    public void SetOwnedItems(Item[] Items)
+    {
+        ownedItems = Items;
+    }
     public virtual bool Promote(out BiddingRound round)
     {
         if (items.Length == 0)

--- a/Assets/Scripts/Auction/WeightedRandomisedAuctionStage.cs
+++ b/Assets/Scripts/Auction/WeightedRandomisedAuctionStage.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using CollectionExtensions;
 using UnityEngine;
 
@@ -24,23 +27,38 @@ public class WeightedRandomisedAuctionStage : RandomisedAuctionStage
     private Item[] RandomSelectionWithReplacement()
     {
         Item[] selection = new Item[numItems];
+        Item[] pool = AvailableSelection();
+
         for (int i = 0; i < numItems; i++)
         {
-            selection[i] = items.RandomElement();
+            selection[i] = pool.RandomElement();
         }
         return selection;
     }
     private Item[] RandomSelectionWithoutReplacement()
     {
-        int[] idx = items.RandomIndicesOf();
+        Item[] pool = AvailableSelection();
+        int[] idx = pool.RandomIndicesOf();
         Item[] selection = new Item[numItems];
+
+        if (pool.Length < numItems)
+            return RandomSelectionWithReplacement();
+
         for (int i = 0; i < numItems; i++)
         {
-            selection[i] = items[idx[i]];
+            selection[i] = pool[idx[i]];
         }
         return selection;
     }
-
+    private Item[] AvailableSelection()
+    {
+        List<Item> newSelection = items.ToList();
+        foreach (Item item in ownedItems)
+        {
+            newSelection.Remove(item);
+        }
+        return newSelection.ToArray();
+    }
     public override bool Promote(out BiddingRound round)
     {
         if (numItems == 0 || items.Length == 0)

--- a/Assets/Scripts/Gamestate/PlayerIdentity.cs
+++ b/Assets/Scripts/Gamestate/PlayerIdentity.cs
@@ -31,7 +31,14 @@ public class PlayerIdentity : MonoBehaviour
     public List<Item> Bodies { get; private set; } = new List<Item>();
     public List<Item> Barrels { get; private set; } = new List<Item>();
     public List<Item> Extensions { get; private set; } = new List<Item>();
-
+    public List<Item> AllItems()
+    {
+        List<Item> allItems = new List<Item>();
+        allItems.AddRange(Bodies);
+        allItems.AddRange(Barrels);
+        allItems.AddRange(Extensions);
+        return allItems;
+    }
     public int Chips { get; private set; } = 0;
     public bool HasMaxChips => Chips >= MatchRules.Current.MaxChips;
 


### PR DESCRIPTION
TODO: In the rare case where all items are bought, auction should be skipped, as of now, it simply fails.

closes #971 