### PR TITLE
Reorder auctions to barrel, extension, body

### DIFF
--- a/Assets/ScriptableObjects/Rules/CustomRulesTemplate.asset
+++ b/Assets/ScriptableObjects/Rules/CustomRulesTemplate.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
 
     Customize objective, rewards and starting
     weapon to your liking.'
+  GameMode: 0
   MatchWinCondition:
     WinCondition: 0
     StopCondition: 0
@@ -47,6 +48,6 @@ MonoBehaviour:
   WeaponProgress:
     Type: 0
   AuctionProgress:
-  - Type: 0
   - Type: 1
   - Type: 2
+  - Type: 0

--- a/Assets/ScriptableObjects/Rules/FirstTo30ChipsRules.asset
+++ b/Assets/ScriptableObjects/Rules/FirstTo30ChipsRules.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   description: Be the first to win a round with 30 chips! Players carry up to 30
     chips at a time and receive limited chip rewards. Spend your chips strategically
     and outsmart your opponents.
-  gameMode: 1
+  GameMode: 1
   MatchWinCondition:
     WinCondition: 2
     StopCondition: 1
@@ -47,6 +47,6 @@ MonoBehaviour:
   WeaponProgress:
     Type: 0
   AuctionProgress:
-  - Type: 0
   - Type: 1
   - Type: 2
+  - Type: 0

--- a/Assets/ScriptableObjects/Rules/SixRoundsRules.asset
+++ b/Assets/ScriptableObjects/Rules/SixRoundsRules.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
 
     Matches
     always last for six rounds. Kills are rewarded.'
-  gameMode: 2
+  GameMode: 2
   MatchWinCondition:
     WinCondition: 0
     StopCondition: 0
@@ -48,6 +48,6 @@ MonoBehaviour:
   WeaponProgress:
     Type: 0
   AuctionProgress:
-  - Type: 0
   - Type: 1
   - Type: 2
+  - Type: 0

--- a/Assets/ScriptableObjects/Rules/ThreeStrikesRules.asset
+++ b/Assets/ScriptableObjects/Rules/ThreeStrikesRules.asset
@@ -48,6 +48,6 @@ MonoBehaviour:
   WeaponProgress:
     Type: 0
   AuctionProgress:
-  - Type: 0
   - Type: 1
   - Type: 2
+  - Type: 0


### PR DESCRIPTION
this makes the most impactful decisions come first, instead of having two bland rounds before getting the chance to pick a different projectile you'll now just have one