### PR TITLE
Fix that ducking revolver issue

### DIFF
--- a/Assets/LazurController.cs
+++ b/Assets/LazurController.cs
@@ -50,8 +50,6 @@ public class LazurController : ProjectileController
     private void Start()
     {
         Vfx.SetGraphicsBuffer("StartEndPositions", encoder.StartEndPositionsBuffer);
-        if (gunController && gunController.GetComponentInChildren<Revolver>())
-            animator.IsDisabledInReload = true;
     }
 
     private void FireLazur()

--- a/Assets/LazurFiringAnimator.cs
+++ b/Assets/LazurFiringAnimator.cs
@@ -7,9 +7,14 @@ public class LazurFiringAnimator : AugmentAnimator
 
     public AnimationEvent OnChargeStart;
 
-    public bool IsDisabledInReload = false;
-
-    public override void OnInitialize(GunStats stats) { }
+    public override void OnInitialize(GunStats stats)
+    {
+        // Determining animation speed by its duration
+        // firerate = 1 / fire duration, animation speed = animation duration / fire duration, ergo this
+        // Using a lil more than reality for animation duration to be certain we don't mess up
+        const float animationDuration = 1.4f;
+        animator.speed = stats.Firerate * animationDuration;
+    }
 
     public override void OnReload(GunStats stats) { }
 
@@ -30,8 +35,6 @@ public class LazurFiringAnimator : AugmentAnimator
 
     public override void OnFire(GunStats stats)
     {
-        if (IsDisabledInReload && stats.Ammo <= 1)
-            return;
         animator.SetTrigger("Fire");
     }
 }

--- a/Assets/Prefabs/GunParts/BrickBarrel.prefab
+++ b/Assets/Prefabs/GunParts/BrickBarrel.prefab
@@ -248,7 +248,7 @@ MonoBehaviour:
   - name: Firerate
     addition: 0
     multiplier: 0
-    exponential: 0.3
+    exponential: 0.7
   - name: Magazine
     addition: 0
     multiplier: 0

--- a/Assets/Prefabs/GunParts/CoilBarrel.prefab
+++ b/Assets/Prefabs/GunParts/CoilBarrel.prefab
@@ -389,7 +389,7 @@ MonoBehaviour:
   - name: Firerate
     addition: 0
     multiplier: 0
-    exponential: 0.5
+    exponential: 0.45
   - name: ScreenShakeFactor
     addition: 0
     multiplier: 0
@@ -421,8 +421,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0
   projectileOutput: {fileID: 0}
-  actualPosition: {x: 0, y: 0, z: 0}
-  actualDirection: {x: 0, y: 0, z: 0}
   projectileRotation: {x: 0, y: 0, z: 0, w: 1}
   stats: {fileID: 0}
   player: {fileID: 0}

--- a/Assets/Prefabs/GunParts/LazurBarrel.prefab
+++ b/Assets/Prefabs/GunParts/LazurBarrel.prefab
@@ -153,6 +153,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animator: {fileID: 595157571004970460}
+  IsFiringDisabled: 0
 --- !u!1 &337387025910078786
 GameObject:
   m_ObjectHideFlags: 0
@@ -584,6 +585,10 @@ MonoBehaviour:
     addition: 0.2
     multiplier: 0
     exponential: 1
+  - name: Firerate
+    addition: 0
+    multiplier: 0
+    exponential: 0.4
   outputs:
   - {fileID: 2021858193588301184}
   midpoint: {fileID: 4423458652456300157}
@@ -620,8 +625,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0
   projectileOutput: {fileID: 0}
-  actualPosition: {x: 0, y: 0, z: 0}
-  actualDirection: {x: 0, y: 0, z: 0}
   projectileRotation: {x: 0, y: 0, z: 0, w: 1}
   stats: {fileID: 0}
   player: {fileID: 0}
@@ -658,7 +661,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pushPower: 20
-  baseFireRateAdder: 2
 --- !u!114 &3946977540612511835
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Augment/AugmentImplementations/CoilFiringAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/CoilFiringAnimator.cs
@@ -4,13 +4,15 @@ public class CoilFiringAnimator : AugmentAnimator
 {
     [SerializeField]
     private Animator animator;
-    private bool isDisabledInReload = false;
+
     public override void OnInitialize(GunStats stats)
     {
-        animator.speed = Mathf.Clamp(stats.Firerate * 1.5f, 1f, 6f);
-        // TODO: Refactor to generalize check instead of this mess
-        if (stats.name.Contains("Revolver"))
-            isDisabledInReload = true;
+        // Determining animation speed by its duration
+        // firerate = 1 / fire duration, animation speed = animation duration / fire duration, ergo this
+        // Using a lil more than reality for animation duration to be certain we don't mess up
+        // Note that firerate accounts for the entire animation here, not each individual shot
+        const float animationDuration = 2.1f;
+        animator.speed = stats.Firerate * animationDuration;
     }
 
     public override void OnReload(GunStats stats)
@@ -19,8 +21,6 @@ public class CoilFiringAnimator : AugmentAnimator
 
     public override void OnFire(GunStats stats)
     {
-        if (isDisabledInReload && stats.Ammo <= 1)
-            return;
         animator.SetTrigger("Fire");
     }
 

--- a/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/RevolverAnimator.cs
@@ -4,11 +4,8 @@ using UnityEngine;
 public class RevolverAnimator : AugmentAnimator
 {
     private Animator animator;
-    private bool canReload = false;
     [SerializeField]
     private Transform attachmentSite;
-    private GunBarrel barrel;
-    private GunExtension extension;
 
     public override void OnFire(GunStats stats) { }
 
@@ -17,22 +14,11 @@ public class RevolverAnimator : AugmentAnimator
         animator = GetComponent<Animator>();
         var playerHands = GetComponentsInChildren<PlayerHand>(includeInactive: true);
         playerHands.ToList().ForEach(hand => Destroy(hand));
-        barrel = transform.parent.gameObject.GetComponentInChildren<GunBarrel>();
-        extension = transform.parent.gameObject.GetComponentInChildren<GunExtension>();
         if (!animator)
             Debug.Log("Revolver Body missing Animator");
     }
 
     public override void OnReload(GunStats stats)
     {
-        canReload = !canReload;
-        if (!canReload)
-            return;
-
-        if (barrel)
-            barrel.transform.SetParent(attachmentSite, true);
-
-        if (extension)
-            extension.transform.SetParent(attachmentSite, true);
     }
 }

--- a/Assets/Scripts/Augment/AugmentImplementations/SateliteUplink.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/SateliteUplink.cs
@@ -125,9 +125,9 @@ public class SateliteUplink : NetworkBehaviour, ProjectileModifier
         projectile.OnProjectileInit -= Track;
         projectile.OnColliderHit -= Target;
         projectile.OnRicochet -= Target;
-        garbagePool.Flush();
+        garbagePool?.Flush();
         garbagePool = null;
-        targetingReticlePool.Flush();
+        targetingReticlePool?.Flush();
         targetingReticlePool = null;
     }
 

--- a/Assets/Scripts/Augment/GunController.cs
+++ b/Assets/Scripts/Augment/GunController.cs
@@ -82,11 +82,6 @@ public class GunController : NetworkBehaviour
 
     private AugmentAnimator barrelAnimator;
 
-    // TODO denne er faktisk ikke i bruk nå siden den ikke blir satt til true lengre.
-    //      -> men hvis du setter den når vi skyter så brekker du spillet
-    //      Fjern denne når/hvis vi har en god erstatning, eller bruk den hvis den funker.
-    private bool isFiring = false;
-
     private int recoilTween;
 
     private void Start()
@@ -173,7 +168,7 @@ public class GunController : NetworkBehaviour
             MatchController.Singleton.onRoundEnd -= CancelZoom;
     }
 
-    private bool ShouldFire() => !isFiring && fireRateController.shouldFire(triggerPressed, triggerHeld);
+    private bool ShouldFire() => fireRateController.shouldFire(triggerPressed, triggerHeld);
 
     [Client]
     private void FixedUpdate()
@@ -291,7 +286,6 @@ public class GunController : NetworkBehaviour
             // hopefully we avoid displaying them in their gruesome nature to the user this way.
             Debug.LogError("Failed to fire gun on owner's client!");
             Debug.LogError(e);
-            isFiring = false;
         }
     }
 
@@ -348,7 +342,6 @@ public class GunController : NetworkBehaviour
     private void FireEnd()
     {
         stats.Ammo = Mathf.Clamp(stats.Ammo - 1, 0, stats.MagazineSize);
-        isFiring = false;
         onFireEnd?.Invoke(stats);
     }
 }

--- a/Assets/Scripts/Augment/GunController.cs
+++ b/Assets/Scripts/Augment/GunController.cs
@@ -82,6 +82,9 @@ public class GunController : NetworkBehaviour
 
     private AugmentAnimator barrelAnimator;
 
+    // TODO denne er faktisk ikke i bruk nå siden den ikke blir satt til true lengre.
+    //      -> men hvis du setter den når vi skyter så brekker du spillet
+    //      Fjern denne når/hvis vi har en god erstatning, eller bruk den hvis den funker.
     private bool isFiring = false;
 
     private int recoilTween;
@@ -288,6 +291,7 @@ public class GunController : NetworkBehaviour
             // hopefully we avoid displaying them in their gruesome nature to the user this way.
             Debug.LogError("Failed to fire gun on owner's client!");
             Debug.LogError(e);
+            isFiring = false;
         }
     }
 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -135,7 +135,7 @@ PlayerSettings:
   vulkanEnableLateAcquireNextImage: 0
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
-  bundleVersion: 0.5.2
+  bundleVersion: 0.5.3
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
pls merge the other one first....

or just review this as both of them maybe

Outlining the issue in Norwegian:
- skyt nest siste skudd (her er ammo > 1)
- vent lenge nok til at animasjonen må være ferdig (mens anim kjører er ammo fortsatt > 1)
- prøv å skyte siste skudd (her er ammo == 1 og også <= 1)
--> da får du ikke skutt

This ammo <= 1 check did fix the animation issue we had with you being able to trigger fire animation just as the body started reloading, but removing this not-fix meant I had to fix it otherwise. Adjusted animation speed to actually correspond to the animation length, and gave the laser barrel an actual reduction in fire rate, and now things seem to work smoothly.

Closes #970 